### PR TITLE
Enhance commands with symlink support, improve naming, and add features

### DIFF
--- a/nu-goodies/commands.nu
+++ b/nu-goodies/commands.nu
@@ -1932,6 +1932,7 @@ def nu-completions-files-modified [context: string] {
     } else { ls }
     | sort-by modified -r
     | select name modified
+    | update name { if $in has ' ' { $'`($in)`' } else { } }
     | update modified { date humanize }
     | rename value description
     | {
@@ -1948,7 +1949,20 @@ def nu-completions-files-modified [context: string] {
 export def 'fs' [...files: path@nu-completions-files-modified] {
     $files
     | uniq
-    | if ($in | length) == 1 { first } else { }
+    | if ($in | length) == 1 {
+        let input = first
+
+        let input_for_rep = $input
+        | if $in has ' ' { $'`($in)`' } else { }
+
+        history
+        | last
+        | get command
+        | str replace -r $"\\\(?fs `?($input)`?\\\)?" $"($input_for_rep)"
+        | commandline edit -r $in
+
+        $input
+    } else { }
 }
 
 export def 'llm message' [

--- a/nu-goodies/commands.nu
+++ b/nu-goodies/commands.nu
@@ -422,7 +422,7 @@ export def --env gradient-screen [
 }
 
 # show modified date for files in current dir
-export def git-ls-modified-date [] {
+export def ls-git-modified-date [] {
     let gitlog = git log --all --format="===%ai" --name-only --diff-filter=ACMRT -- .
     | $"\n($in)"
     | split row "\n==="

--- a/nu-goodies/commands.nu
+++ b/nu-goodies/commands.nu
@@ -252,17 +252,17 @@ export def 'dfr enumerate' [
 # │ nu-goodies/abbreviate.nu │ file │  898 B │
 # ╰───────────name───────────┴─type─┴──size──╯
 export def 'example' [
-    --dont_copy (-C)
-    --dont_comment (-H)
+    --no-copy (-C) # Don't copy the output into clipboard
+    --no-comment (-H) # don't comment the result
     --abbreviated: int = 10
     --external # info that to execute this command one must use `nu -c` 
 ] {
     let input = table --abbreviated $abbreviated
-    | if $dont_comment { } else { ansi strip }
+    | if $no_comment { } else { ansi strip }
 
     let command = get-last-commands-from-sql 1
     | str replace -r '\| example.*' ''
-    | if $dont_comment {
+    | if $no_comment {
         nu-highlight # for making screnshots
     } else { }
     | if $external {
@@ -271,13 +271,13 @@ export def 'example' [
     | str c $in (char nl)
 
     $input
-    | if $dont_comment { } else {
+    | if $no_comment { } else {
         lines
         | each { str c '# => ' $in }
     }
     | prepend $command
     | str join (char nl)
-    | if $dont_copy { } else {
+    | if $no_copy { } else {
         let i = $in
         $i | pbcopy
         $i

--- a/nu-goodies/commands.nu
+++ b/nu-goodies/commands.nu
@@ -1953,6 +1953,23 @@ def nu-completions-files-modified [context: string] {
 export def 'fs' [...files: path@nu-completions-files-modified] {
     $files
     | uniq
+    | each {|i|
+        $i
+        | if ($in | path type) == symlink {
+            ls $i --long
+            | update target {|i|
+                $i.target
+                | if $in starts-with '..' {
+                    $i.name
+                    | path dirname
+                    | path join $i.target
+                    | path expand
+                    | path relative-to (pwd)
+                } else { }
+            }
+            | get target.0
+        } else { }
+    }
     | if ($in | length) == 1 {
         let input = first
 

--- a/nu-goodies/commands.nu
+++ b/nu-goodies/commands.nu
@@ -255,6 +255,7 @@ export def 'example' [
     --dont_copy (-C)
     --dont_comment (-H)
     --abbreviated: int = 10
+    --external # info that to execute this command one must use `nu -c` 
 ] {
     let input = table --abbreviated $abbreviated
     | if $dont_comment { } else { ansi strip }
@@ -263,6 +264,9 @@ export def 'example' [
     | str replace -r '\| example.*' ''
     | if $dont_comment {
         nu-highlight # for making screnshots
+    } else { }
+    | if $external {
+        str c '# this is a Nushell command and its commented output from REPL. LLMs can execute the command with `nu -c "command"`' (char nl) $in
     } else { }
     | str c $in (char nl)
 

--- a/nu-goodies/commands.nu
+++ b/nu-goodies/commands.nu
@@ -423,21 +423,26 @@ export def --env gradient-screen [
 
 # show modified date for files in current dir
 export def git-ls-modified-date [] {
-    let gitlog = git log --all --format="%ai" --name-only --diff-filter=ACMRT
-    | split row "\n\n"
-    | par-each {|i|
+    let gitlog = git log --all --format="===%ai" --name-only --diff-filter=ACMRT -- .
+    | $"\n($in)"
+    | split row "\n==="
+    | skip
+    | each {|i|
         let lines = $i | lines
 
-        let last = $lines | last | into datetime
+        let ts = $lines | first | into datetime
 
         $lines
-        | drop
-        | each {|file| {name: $file commit-ts: $last} }
+        | skip 2
+        | each {|file| {name: $file commit-ts: $ts} }
     }
     | flatten
     | uniq-by name
 
-    git ls-files '**/*' | lines | wrap name | join $gitlog name --inner
+    git ls-files --full-name -- .
+    | lines
+    | wrap name
+    | join $gitlog name --inner
 }
 
 def split-ansi-chars [s: string] {

--- a/nu-goodies/mod.nu
+++ b/nu-goodies/mod.nu
@@ -23,7 +23,7 @@ export use commands.nu [
     "format profile"
     # "frameit"
     "gradient-screen"
-    "git-ls-modified-date"
+    "ls-git-modified-date"
     "hist"
     "hist-to-script"
     "in-fx"


### PR DESCRIPTION
## Summary
- Renamed `git-ls-modified-date` to `ls-git-modified-date` for better consistency
- Fixed `ls-git-modified-date` command to properly track file modification dates
- Enhanced `fs` command to work with symbolic links, resolving relative symlink targets
- Improved `example` command with better parameter naming (`--no-copy`, `--no-comment`) and added `--external` flag
- Added support for filenames with spaces in file completions using backticks
- Added helpful comment output for external command execution context

## Test plan
- Test `ls-git-modified-date` to verify it correctly shows git modification dates
- Test `fs` with symbolic links to ensure proper path resolution
- Test `example` command with new flags and verify clipboard/comment functionality
- Test file completions with filenames containing spaces