### PR TITLE
Refactor: code style standardization and improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
 zzz_md*
+.claude/settings.local.json

--- a/nu-goodies/commands.nu
+++ b/nu-goodies/commands.nu
@@ -76,6 +76,7 @@ export def 'bar' [
 ###file bye.nu
 # use gradient-screen.nu
 
+# Display gradient screen and exit the shell
 export def 'bye' [
     ...strings: string
     --no_date # Don't append date
@@ -98,8 +99,9 @@ export def 'cb' [
 }
 
 ###file center.nu
+# Center text within terminal width
 export def 'center' [
-    --factor: int = 1
+    --factor: int = 1 # Divide terminal width by this factor
 ] {
     fill -a center --width ((term size).columns // $factor)
 }
@@ -156,6 +158,7 @@ export def 'cprint' [
 # I `export` commands here to make them available for testing, while still
 # keeping them in the same file so cprint can be easily copied to other projects
 
+# Calculate safe text width accounting for terminal size and indent
 export def 'width-safe' [
     $width
     $indent
@@ -167,6 +170,7 @@ export def 'width-safe' [
     | [$in 1] | math max # term size gives 0 in tests
 }
 
+# Wrap text to specified width, optionally preserving line breaks
 export def 'wrapit' [
     $keep_single_breaks
     $width_safe
@@ -179,12 +183,14 @@ export def 'wrapit' [
     | str replace -r $'\s+$' '' # trailing new line
 }
 
+# Collapse single newlines into spaces, preserve double newlines as paragraphs
 export def 'remove_single_nls' [] {
     str replace -r -a '(\n[\t ]*){2,}' '⏎'
     | str replace -arm '(?<!⏎)\n' ' ' # remove single line breaks used for code formatting
     | str replace -a '⏎' "\n\n"
 }
 
+# Add newlines before and after text
 export def 'newlineit' [
     $before
     $after
@@ -192,6 +198,7 @@ export def 'newlineit' [
     $"((char nl) | str repeat $before)($in)((char nl) | str repeat $after)"
 }
 
+# Wrap text with decorative frame lines above and below
 export def 'frameit' [
     $width_safe
     $frame
@@ -206,6 +213,7 @@ export def 'frameit' [
     | $in + "\n" + $input + "\n" + $in
 }
 
+# Apply color and highlight *emphasized* text
 export def 'colorit' [
     $highlight_color
     $color
@@ -214,6 +222,7 @@ export def 'colorit' [
     | str c (ansi $color) $in (ansi reset)
 }
 
+# Align each line of text within specified width
 export def 'alignit' [
     $alignment: string
     $width_safe
@@ -223,6 +232,7 @@ export def 'alignit' [
     | str join (char nl)
 }
 
+# Add leading spaces to each line
 export def 'indentit' [
     $indent
 ] {
@@ -410,7 +420,7 @@ export def --env gradient-screen [
     }
 }
 
-# Show modified date for files in current directory
+# Show git commit dates for files, excluding bulk-change commits
 export def ls-git-modified-date [
     path?: path
     --max-files-in-commit: int = 5 # skip commits with more than this number of files. Useful for excluding automatic changes such as those by prettier or ruff
@@ -616,9 +626,9 @@ export def --wrapped in-fx [
     | ^fx ...$rest
 }
 
-# Open piped-in results in hx, output back the saved file
+# Open data in Helix editor, return edited content to commandline
 export def 'in-hx' [
-    --path (-p) # Output path of the file
+    --path (-p) # Output file path instead of content
 ] {
     let input = $in
     let type = $input | describe
@@ -760,7 +770,7 @@ export def --env ln-for-preview [
 # }
 
 ###file mc.nu
-# Open midnight commander, cd to the last folder
+# Open Midnight Commander and cd to its exit directory
 export def --env mc [
     path1?: path
     path2?: path
@@ -813,7 +823,7 @@ export def 'mv1' [
 }
 
 ###file mygit log.nu
-# Commit current version of dot files and apps settings
+# Backup dotfiles and config directories to their git repos
 export def 'mygit log' [
     --message (-m): string
 ] {
@@ -847,6 +857,7 @@ export def 'mygit log' [
     }
 }
 
+# Backup Nushell history database to timestamped SQL dump
 export def 'history-backup' [] {
     let hist_backups_dir = '~/.config/nushell/history-backups/'
     | path expand
@@ -943,6 +954,7 @@ export def 'nu-test install' [
     commandline edit -r $'^($cargo_test_path | path join bin nu) --plugin-config ($plugin_config)'
 }
 
+# Launch the test-installed Nushell binary
 export def 'nu-test launch' [
     --no-plugin
 ] {
@@ -960,6 +972,7 @@ export def 'nu-test launch' [
 
 const nightly_path = '~/temp/nu-nightly' | path expand
 
+# Download and extract latest Nushell nightly build
 export def --env download-nushell-nightly [
     --arch (-a): string = 'aarch64-apple-darwin' # Architecture as specified in nushell/nightly repo
     --ext (-e): string = '.tar.gz' # Extension, including the leading dot (e.g. '.tar.gz')
@@ -986,6 +999,7 @@ export def --env download-nushell-nightly [
     tar -C $nightly_path -xzf $destination_file
 }
 
+# Launch the most recent downloaded nightly Nushell
 export def 'launch-downloaded' [] {
     let path = glob ($nightly_path | path join *darwin *nu) | sort | last
     commandline edit -r $path
@@ -1103,6 +1117,7 @@ export def 'number-format' [
 }
 
 ###file orbita.nu
+# Generate 14 lines of spaces (placeholder grid)
 export def 'orbita' [] {
     1..14 | each { line ' ' }
 }
@@ -1160,12 +1175,13 @@ export def 'select-i' [] {
 }
 
 ###file side-by-side.nu
+# Display two tables side by side for comparison
 export def 'side-by-side' [
-    r
-    --delimiter: string = ' ' # Delimiter between left and right
-    --collapse # Use collapsed table representation
-    --l_header: string
-    --r_header: string
+    r # Right side table
+    --delimiter: string = ' ' # Separator between columns
+    --collapse # Use compact table format
+    --l_header: string # Left table header label
+    --r_header: string # Right table header label
 ] {
     mut $l = $in | if $collapse { table } else { table -e } | into string | lines
     mut $r = $r | if $collapse { table } else { table -e } | into string | lines
@@ -1293,6 +1309,7 @@ export def 'significant-digits' [
 alias std_append = append
 alias std_prepend = prepend
 
+# Repeat a string n times
 export def 'str repeat' [
     $n
 ] {
@@ -1300,6 +1317,7 @@ export def 'str repeat' [
     seq 1 $n | each { $text } | str join
 }
 
+# Append strings with optional separators
 export def 'str append' [
     ...text: string
     --space (-s)
@@ -1325,6 +1343,7 @@ export def 'str append' [
     $"($input)($concatenator)($text | str join $rest_el)"
 }
 
+# Prepend strings with optional separators
 export def 'str prepend' [
     ...text: string
     --space (-s)
@@ -1350,10 +1369,13 @@ export def 'str prepend' [
     $"($text | str join $rest_el)($concatenator)($input)"
 }
 
+# Add indentation to text (not implemented)
 export def 'indent' [] { }
 
+# Remove indentation from text (not implemented)
 export def 'dedent' [] { }
 
+# Escape regex special characters in a string
 export def 'escape-regex' [] {
     let input = $in
     let regex = '\.^$*+?{}()[]|/' | split chars | each { $'\($in)' } | str join '|' | $"\(($in))"
@@ -1361,18 +1383,21 @@ export def 'escape-regex' [] {
     $input | str replace --all --regex $regex '\$1'
 }
 
+# Escape Nushell special characters for string interpolation
 export def 'escape-nushell-escapes' [] {
     str replace --all --regex '(\\|\"|\/|\(|\)|\{|\}|\$|\^|\#|\||\~)' '\$1'
 }
 
 ###file testcd.nu
+# Test helper for cd command
 export def --env 'testcd' [destination] { cd $destination }
 
+# Convert string to filesystem-safe filename
 export def 'to-safe-filename' [
-    --prefix: string = ''
-    --suffix: string = ''
-    --regex: string = '[^A-Za-z0-9_А-Яа-я+]' # Symbols to keep
-    --date
+    --prefix: string = '' # Prepend to filename
+    --suffix: string = '' # Append to filename
+    --regex: string = '[^A-Za-z0-9_А-Яа-я+]' # Characters to replace
+    --date # Prepend timestamp for uniqueness
 ]: string -> string {
     str replace -ra $regex '_'
     | str replace -ra '__+' '_'
@@ -1407,6 +1432,7 @@ export def 'to-temp-file' [
 }
 
 ###file transcribe.nu
+# Transcribe audio file to text using whisper.cpp
 export def 'transcribe' [file: path] {
     let file = $file
     | if $in =~ '\.wav$' { } else {
@@ -1423,11 +1449,12 @@ export def 'transcribe' [file: path] {
 }
 
 ###file wez-to-ansi.nu
+# Capture recent commands from Wezterm scrollback with ANSI codes
 export def 'wez-to-ansi' [
     $n_last_commands: int = 2 # Number of recent commands (and outputs) to capture.
     --regex: string = '^>' # Regex to separate prompts from outputs. Default is ''.
     --lines_before_top_of_term: int = 100 # Lines from top of scrollback in Wezterm to capture.
-    --min_term_width: int = 0
+    --min_term_width: int = 0 # Minimum output width (pads with spaces)
 ] {
 
     # let regex = '^' + (ansi green_italic) + '>'
@@ -1448,9 +1475,10 @@ export def 'wez-to-ansi' [
     | str join (char nl)
 }
 
+# Record Wezterm session to asciicast format
 export def 'wez-to-asciicast' [
-    command: string = ''
-    --filename: path
+    command: string = '' # Command to record
+    --filename: path # Output file path
 ]: nothing -> path {
     let wezrec = ^wezterm record --cwd (pwd) -- $nu.current-exe --execute $'source $nu.env-path; clear; ($command)'
     | complete
@@ -1467,10 +1495,11 @@ export def 'wez-to-asciicast' [
     $target_folder | path join ($wezrec | path basename)
 }
 
+# Record Wezterm session and convert to GIF
 export def 'wez-to-gif' [
-    --filename: path
-    --font-family: string = "ZedMono Nerd Font"
-    --font-size: int = 20
+    --filename: path # Output GIF path
+    --font-family: string = "ZedMono Nerd Font" # Font for rendering
+    --font-size: int = 20 # Font size in pixels
 ] {
 
     let wezrec = wez-to-asciicast
@@ -1688,12 +1717,12 @@ def zellij-navigate [
     true
 }
 
-# Main z command
+# Jump to directory from history using fuzzy search
 export def --env 'z' [
-    query?: string@'nu-completions-cwds' # Directory query to search for (optional)
-    --interactive (-i) # Force interactive mode
-    --new-tab (-n) # Open directory in a new Zellij tab
-    --update-dead-dirs (-u) # Refresh the list of nonexistent directories
+    query?: string@'nu-completions-cwds' # Fuzzy search query for directory
+    --interactive (-i) # Always show interactive picker
+    --new-tab (-n) # Open in new Zellij tab
+    --update-dead-dirs (-u) # Rebuild nonexistent directories cache
 ]: nothing -> nothing {
     # Handle update dead dirs
     if $update_dead_dirs {
@@ -1719,6 +1748,7 @@ export def --env 'z' [
     }
 }
 
+# Generate completions for z command from history
 export def 'nu-completions-cwds' [] {
     # Using SQL-level filtering for completions as well
     init-dead-cwds-table
@@ -1772,13 +1802,14 @@ export def 'nu-completions-cwds' [] {
     }
 }
 
+# Find and replace text across multiple files by extension
 export def 'replace-in-all-files' [
-    find
-    replace
-    --quiet # Don't output stats
-    --no-git-check
-    --no-rg
-    --extensions: list = [nu md py] # Might be '{nu,md}' or single ext like `py`
+    find # Text to search for
+    replace # Replacement text
+    --quiet # Suppress statistics output
+    --no-git-check # Skip uncommitted changes check
+    --no-rg # Use Nushell instead of ripgrep
+    --extensions: list = [nu md py] # File extensions to process
 ] {
     let glob = $extensions
     | str join ','
@@ -1817,6 +1848,7 @@ export def 'replace-in-all-files' [
     }
 }
 
+# Error if file has uncommitted git changes
 export def 'check-clean-working-tree' [
     $module_path: path
 ] {
@@ -1856,9 +1888,9 @@ def 'insert-new-lines' [] {
     | str join
 }
 
-# Format piped in Nushell code or previous command from history using Topiary.
+# Format Nushell code using Topiary formatter
 export def 'nu-format' [
-    --no-new-lines (-n) # Don't insert new lines
+    --no-new-lines (-n) # Skip automatic line breaks before pipes
 ]: [nothing -> nothing string -> string] {
     let input = $in
 
@@ -1903,6 +1935,7 @@ def nu-completions-files-modified [context: string] {
     }
 }
 
+# Resolve symlinks and return target paths, sorted by modification time
 export def 'fs' [...files: path@nu-completions-files-modified] {
     $files
     | uniq
@@ -1928,6 +1961,7 @@ export def 'fs' [...files: path@nu-completions-files-modified] {
     } else { }
 }
 
+# Retrieve LLM conversation messages by hash suffix
 export def 'llm message' [
     ...rest: string@completion-llm-message
 ] {
@@ -1944,12 +1978,14 @@ export def 'llm message' [
     | str join "\n\n---\n\n"
 }
 
+# Load and deduplicate LLM conversation log
 export def 'llm-open-log' [] {
     open ~/short_log.yaml
     | uniq-by content-hash
     | sort-by timestamp -r
 }
 
+# Generate completions for llm message command
 export def 'completion-llm-message' [
     --first: int = 200
 ] {
@@ -2003,10 +2039,12 @@ export def find-root [dir?: path]: [nothing -> path nothing -> nothing] {
     }
 }
 
+# Change directory to git repository root
 export def --env cd-root [dir?: path]: [nothing -> nothing] {
     cd (find-root)
 }
 
+# Preview text in all available figlet fonts
 export def figlet-demo [text: string] {
     glob /opt/homebrew/Cellar/figlet/2.2.5/share/figlet/fonts/*.flf
     | par-each {|i|
@@ -2020,7 +2058,7 @@ export def figlet-demo [text: string] {
     | reduce {|i| merge $i }
 }
 
-# Rename zellij tab
+# Rename Zellij tab, auto-incrementing duplicates
 export def rename-tab [name: string = ''] {
     let name = if $name == '' { pwd | path basename | str replace -r '^-+' '' } else { $name }
 

--- a/nu-goodies/commands.nu
+++ b/nu-goodies/commands.nu
@@ -1605,33 +1605,26 @@ def remove-dead-dir [
     | query db "DELETE FROM dead_cwds WHERE path = ?" -p [$dir]
 }
 
-# Helper function to handle dead directories
-def handle-dead-dirs [
-    --update (-u) # Force update of dead directories list
-]: nothing -> list<string> {
-    if $update {
-        # Get all directories including those already marked as dead
-        let all_cwds = get-history-dirs --include-dead
+# Scan history directories and rebuild the dead_cwds table with non-existent paths
+def update-dead-dirs []: nothing -> list<string> {
+    # Get all directories including those already marked as dead
+    let all_cwds = get-history-dirs --include-dead
 
-        # Check which directories no longer exist
-        let dead_cwds = $all_cwds
-        | where {|dir| $dir | path exists | not $in }
+    # Check which directories no longer exist
+    let dead_cwds = $all_cwds
+    | where {|dir| $dir | path exists | not $in }
 
-        # Clear existing dead_cwds table and insert new values
-        init-dead-cwds-table
-        open $nu.history-path
-        | query db "DELETE FROM dead_cwds"
+    # Clear existing dead_cwds table and insert new values
+    init-dead-cwds-table
+    open $nu.history-path
+    | query db "DELETE FROM dead_cwds"
 
-        # Insert each dead directory
-        $dead_cwds | each {|dir|
-            add-dead-dir $dir
-        }
-
-        $dead_cwds
-    } else {
-        # Load existing dead directories list
-        read-dead-dirs
+    # Insert each dead directory
+    $dead_cwds | each {|dir|
+        add-dead-dir $dir
     }
+
+    $dead_cwds
 }
 
 # Helper function to select a directory path
@@ -1731,7 +1724,7 @@ export def --env 'z' [
     # Handle update dead dirs
     if $update_dead_dirs {
         print "Updating dead directories list..."
-        handle-dead-dirs --update=true
+        update-dead-dirs
         return
     }
 

--- a/nu-goodies/commands.nu
+++ b/nu-goodies/commands.nu
@@ -1854,7 +1854,7 @@ export def 'replace-in-all-files' [
 export def git-check-file-clean [
     file: path
 ] {
-    let git_status = git status --short -- $file
+    let git_status = git status --porcelain -- $file
 
     if ($git_status | is-not-empty) {
         error make --unspanned {

--- a/nu-goodies/commands.nu
+++ b/nu-goodies/commands.nu
@@ -79,10 +79,10 @@ export def 'bar' [
 # Display gradient screen and exit the shell
 export def 'bye' [
     ...strings: string
-    --no_date # Don't append date
+    --no-date # Don't append date
     -n # don't quit
 ] {
-    gradient-screen ...$strings --no_date=$no_date
+    gradient-screen ...$strings --no-date=$no_date
     if not $n { exit }
 }
 
@@ -128,13 +128,13 @@ export def 'copy-cmd' [] {
 export def 'cprint' [
     text?: string # Text to format, if omitted stdin will be used
     --color (-c): string@'nu-complete-colors' = 'default' # Color to use for the cprint text
-    --highlight_color (-H): string@'nu-complete-colors' = 'green_bold' # Color to use for highlighting text enclosed in asterisks
-    --frame_color (-r): string@'nu-complete-colors' = 'dark_gray' # Color to use for frame
+    --highlight-color (-H): string@'nu-complete-colors' = 'green_bold' # Color to use for highlighting text enclosed in asterisks
+    --frame-color (-r): string@'nu-complete-colors' = 'dark_gray' # Color to use for frame
     --frame (-f): string = '' # Symbol (or a string) to frame a text
-    --lines_before (-b): int = 0 # Number of new lines before a text
-    --lines_after (-a): int = 1 # Number of new lines after a text
+    --lines-before (-b): int = 0 # Number of new lines before a text
+    --lines-after (-a): int = 1 # Number of new lines after a text
     --echo (-e) # Echo text string instead of printing
-    --keep_single_breaks # Don't remove single line breaks
+    --keep-single-breaks # Don't remove single line breaks
     --width (-w): int = 80 # The total width of text to wrap it
     --indent (-i): int = 0 # Indent output by number of spaces
     --align: string = 'left' # Alignment of text
@@ -348,7 +348,7 @@ export def 'format profile' [] {
 # Fill screen with repeated texts from arguments or $env.gradient-screen.texts with random color gradient
 export def --env gradient-screen [
     ...strings: string
-    --no_date # Don't append date
+    --no-date # Don't append date
     --echo
     --rows: int
 ] {
@@ -510,7 +510,7 @@ alias core_hist = history
 # Filter history with regex and convenient flags, add useful columns
 export def 'hist' [
     like_filter?: string # a string to search in db
-    --regex_filters: list<string> = [] # a regex to search for
+    --regex-filters: list<string> = [] # a regex to search for
     --entries: int = 5000 # A number of last entries to work with
     --all (-a) # Return all the history
     --session (-s) # Show only entries from the current session
@@ -580,10 +580,10 @@ export def 'hist' [
 # Save significant or all current session history entries into a .nu file. If the .nu file already exists, data will be appended.
 export def 'hist-to-script' [
     filename?: path
-    --dont_open (-O) # Don't open the saved history file in editor
+    --dont-open (-O) # Don't open the saved history file in editor
     --up (-u): int = 0 # Set number of last events to save
     --all # Save all history into .nu file
-    --directory_hist # Get history for a directory instead of session
+    --directory-hist # Get history for a directory instead of session
 ] {
     let session = history session
 
@@ -799,7 +799,7 @@ export def --env mc [
 export def --env md [
     target_dir
     -d # Use standard directory
-    --dest_dir: path = '/Users/user/temp'
+    --dest-dir: path = '/Users/user/temp'
 ] {
     let dir = (
         if $d or ($dest_dir != '/Users/user/temp') {
@@ -981,7 +981,7 @@ const nightly_path = '~/temp/nu-nightly' | path expand
 export def --env download-nushell-nightly [
     --arch (-a): string = 'aarch64-apple-darwin' # Architecture as specified in nushell/nightly repo
     --ext (-e): string = '.tar.gz' # Extension, including the leading dot (e.g. '.tar.gz')
-    --destination_dir (-d): directory = $nightly_path # Destination directory in which to save the download
+    --destination-dir (-d): directory = $nightly_path # Destination directory in which to save the download
 ] {
     let most_recent_nightly = (http get https://api.github.com/repos/nushell/nightly/releases | get 0)
     let nightly_name = ($most_recent_nightly.name | str replace -r '^Nu-nightly-' '')
@@ -1015,17 +1015,17 @@ export def 'launch-downloaded' [] {
 
 # Format number column in a table using number-format
 #
-# > [[a]; [123456.678] [2345.8900]] | number-col-format a --denom wt --decimals 2 --significant_digits 3
+# > [[a]; [123456.678] [2345.8900]] | number-col-format a --denom wt --decimals 2 --significant-digits 3
 # ╭──────a───────╮
 # │ 123_000.00wt │
 # │   2_340.00wt │
 # ╰──────────────╯
 export def 'number-col-format' [
     column_name: string # A column name to format
-    --thousands_delim (-t) = '_' # Thousands delimiter: number-format 1000 -t ': 1'000
+    --thousands-delim (-t) = '_' # Thousands delimiter: number-format 1000 -t ': 1'000
     --decimals (-d) = 0 # Number of digits after decimal delimiter: number-format 1000.1234 -d 2: 1000.12
     --denom (-D) = '' # Denom `--denom "Wt": number-format 1000 --denom 'Wt': 1000Wt
-    --significant_digits: int = 0 # The number of first digits to display, others will become 0
+    --significant-digits: int = 0 # The number of first digits to display, others will become 0
 ] {
     let input = $in
 
@@ -1055,8 +1055,8 @@ export def 'number-col-format' [
         (
             number-format ($i | get $column_name)
             --denom $denom --decimals $decimals
-            --thousands_delim $thousands_delim --integers $integers
-            --significant_digits $significant_digits
+            --thousands-delim $thousands_delim --integers $integers
+            --significant-digits $significant_digits
         )
     }
 }
@@ -1066,7 +1066,7 @@ export def 'number-col-format' [
 
 # Format big numbers nicely
 #
-# > number-format 1000 --thousands_delim "'"
+# > number-format 1000 --thousands-delim "'"
 # 1'000
 #
 # > number-format 123 --integers 6
@@ -1079,9 +1079,9 @@ export def 'number-col-format' [
 # 1_000Wt
 export def 'number-format' [
     num? # Number to format
-    --thousands_delim (-t): string = '_' # Thousands delimiter
+    --thousands-delim (-t): string = '_' # Thousands delimiter
     --integers (-i): int = 0 # Length of padding whole-part digits
-    --significant_digits: int = 0 # The number of first digits to display, others will become 0
+    --significant-digits: int = 0 # The number of first digits to display, others will become 0
     --decimals (-d): int = 0 # Number of digits after decimal delimiter
     --denom (-D): string = '' # Denom
     --color: string = 'green'
@@ -1185,8 +1185,8 @@ export def 'side-by-side' [
     r # Right side table
     --delimiter: string = ' ' # Separator between columns
     --collapse # Use compact table format
-    --l_header: string # Left table header label
-    --r_header: string # Right table header label
+    --l-header: string # Left table header label
+    --r-header: string # Right table header label
 ] {
     mut $l = $in | if $collapse { table } else { table -e } | into string | lines
     mut $r = $r | if $collapse { table } else { table -e } | into string | lines
@@ -1330,7 +1330,7 @@ export def 'str append' [
     --new-line (-n)
     --tab (-t)
     --concatenator (-c): string = '' # Input and rest concatenator
-    --rest_el: string = ' ' # Rest elements concatenator
+    --rest-el: string = ' ' # Rest elements concatenator
 ] {
     let input = $in
     let concatenator = $"(
@@ -1356,7 +1356,7 @@ export def 'str prepend' [
     --new-line (-n)
     --tab (-t)
     --concatenator (-c): string = '' # Input and rest concatenator
-    --rest_el: string = ' ' # Rest elements concatenator
+    --rest-el: string = ' ' # Rest elements concatenator
 ] {
     let input = $in
     let concatenator = $"(
@@ -1458,8 +1458,8 @@ export def 'transcribe' [file: path] {
 export def 'wez-to-ansi' [
     n_last_commands: int = 2 # Number of recent commands (and outputs) to capture.
     --regex: string = '^>' # Regex to separate prompts from outputs. Default is ''.
-    --lines_before_top_of_term: int = 100 # Lines from top of scrollback in Wezterm to capture.
-    --min_term_width: int = 0 # Minimum output width (pads with spaces)
+    --lines-before-top-of-term: int = 100 # Lines from top of scrollback in Wezterm to capture.
+    --min-term-width: int = 0 # Minimum output width (pads with spaces)
 ] {
 
     # let regex = '^' + (ansi green_italic) + '>'
@@ -1533,7 +1533,7 @@ export def 'wez-to-gif' [
 # Capture wezterm scrollback, split by prompts, output chosen ones to an image file
 export def 'wez-to-png' [
     n_last_commands: int = 2 # Number of recent commands (and outputs) to capture.
-    --output_path: path = '' # Path for saving output images.
+    --output-path: path = '' # Path for saving output images.
 ] {
     let output_path = $output_path
     | if $in != '' { } else {

--- a/nu-goodies/commands.nu
+++ b/nu-goodies/commands.nu
@@ -1798,23 +1798,23 @@ export def 'replace-in-all-files' [
         | lines
     }
 
-    mut $rec = {
-        $'total .($extensions) files': ($files_total | length)
-        'updated': 0
-    }
-
-    for $i in $files_found {
+    let updated = $files_found
+    | each {|i|
         if not $no_git_check { check-clean-working-tree $i }
 
         $i | open
         | str replace -a $find $replace
         | str replace -r '\n*$' (char nl)
         | save -f $i
-
-        $rec.updated += 1
     }
+    | length
 
-    if not $quiet { $rec }
+    if not $quiet {
+        {
+            $'total .($extensions) files': ($files_total | length)
+            'updated': $updated
+        }
+    }
 }
 
 export def 'check-clean-working-tree' [

--- a/nu-goodies/commands.nu
+++ b/nu-goodies/commands.nu
@@ -1841,8 +1841,10 @@ export def 'replace-in-all-files' [
     | length
 
     if not $quiet {
+        let field_name = $'total .($extensions) files'
+        # I use record here just for decoration
         {
-            $'total .($extensions) files': ($files_total | length)
+            $field_name: ($files_total | length)
             'updated': $updated
         }
     }

--- a/nu-goodies/commands.nu
+++ b/nu-goodies/commands.nu
@@ -1683,18 +1683,18 @@ def zellij-tab-names []: nothing -> list<string> {
     zellij action query-tab-names | lines
 }
 
-# Helper function to handle Zellij integration
-def handle-zellij [
+# Returns true if caller should cd, false if Zellij handled navigation
+def zellij-need-cd [
     $path: string # Target directory path
     $dir_name: string # Directory name for tab
     --new-tab (-n) # Open in new tab
 ]: nothing -> bool {
-    if ($env.ZELLIJ? | is-empty) { return false }
+    if ($env.ZELLIJ? | is-empty) { return true }
 
     if $new_tab {
         # Create new tab with the directory
         zellij action new-tab --layout default --cwd $path --name $dir_name
-        return true
+        return false
     }
 
     # Check if tab with this name already exists
@@ -1705,12 +1705,12 @@ def handle-zellij [
     if ($matching_tab | is-not-empty) and ([true false] | input list 'switch to tab') {
         # Switch to existing tab
         zellij action go-to-tab-name $matching_tab
-        return true
+        return false
     }
 
     # Rename current tab
     zellij action rename-tab $dir_name
-    false
+    true
 }
 
 # Main z command
@@ -1759,9 +1759,7 @@ export def --env 'z' [
     # Get directory name for tab naming
     let dir_name = $target_path | path split | last
 
-    # Handle Zellij integration
-    # Change to the target directory if not handled by Zellij new tab
-    if not (handle-zellij $expanded_path $dir_name --new-tab=$new_tab) {
+    if (zellij-need-cd $expanded_path $dir_name --new-tab=$new_tab) {
         cd $expanded_path
     }
 }

--- a/nu-goodies/commands.nu
+++ b/nu-goodies/commands.nu
@@ -539,9 +539,8 @@ export def 'hist' [
         $results
     } else {
         $regex_filters
-        | reduce -f $results {|pattern acc|
-            $acc
-            | where command =~ $pattern
+        | reduce --fold $results {|pattern|
+            where command =~ $pattern
         }
     }
 

--- a/nu-goodies/commands.nu
+++ b/nu-goodies/commands.nu
@@ -3,12 +3,12 @@
 export def 'L' [
     --abbreviated (-a): int = 1000
     --bat (-b) # Use bat instead of less
-] {
+]: any -> nothing {
     table -e --abbreviated $abbreviated | into string | if $bat { bat } else { less -R }
 }
 
 ###file O.nu
-def nu-complete-macos-apps [] {
+def nu-complete-macos-apps []: nothing -> list<string> {
     ls /Applications -s | get name | each { str replace '.app' '' | $'"($in)"' }
 }
 
@@ -44,7 +44,7 @@ export def 'bar' [
     --foreground (-f): string = 'default'
     --progress (-p) # Output the result using 'print -n'
     --width (-w): int = 5
-] {
+]: nothing -> string {
     let blocks = [null "▏" "▎" "▍" "▌" "▋" "▊" "▉" "█"]
     let full_bar = $blocks | last
     let whole_part = ($percentage * $width) // 1
@@ -81,7 +81,7 @@ export def 'bye' [
     ...strings: string
     --no-date # Don't append date
     -n # don't quit
-] {
+]: nothing -> nothing {
     gradient-screen ...$strings --no-date=$no_date
     if not $n { exit }
 }
@@ -90,7 +90,7 @@ export def 'bye' [
 # Shortcut for pbpaste and pbcopy. But is it needed?
 export def 'cb' [
     --paste
-] {
+]: [any -> nothing nothing -> string] {
     if $paste or ($in == null) {
         pbpaste
     } else {
@@ -102,13 +102,13 @@ export def 'cb' [
 # Center text within terminal width
 export def 'center' [
     --factor: int = 1 # Divide terminal width by this factor
-] {
+]: string -> string {
     fill -a center --width ((term size).columns // $factor)
 }
 
 ###file copy-cmd.nu
 # Copy this command to clipboard
-export def 'copy-cmd' [] {
+export def 'copy-cmd' []: nothing -> nothing {
     let commands = history
     | last 2
     | get command
@@ -160,9 +160,9 @@ export def 'cprint' [
 
 # Calculate safe text width accounting for terminal size and indent
 export def 'width-safe' [
-    $width
-    $indent
-] {
+    width: int
+    indent: int
+]: nothing -> int {
     term size
     | get columns
     | [$in $width] | math min
@@ -172,10 +172,10 @@ export def 'width-safe' [
 
 # Wrap text to specified width, optionally preserving line breaks
 export def 'wrapit' [
-    $keep_single_breaks
-    $width_safe
-    $indent
-] {
+    keep_single_breaks: bool
+    width_safe: int
+    indent: int
+]: string -> string {
     str replace -arm '^[\t ]+' ''
     | if $keep_single_breaks { } else { remove_single_nls }
     | str replace -arm '[\t ]+$' ''
@@ -184,7 +184,7 @@ export def 'wrapit' [
 }
 
 # Collapse single newlines into spaces, preserve double newlines as paragraphs
-export def 'remove_single_nls' [] {
+export def 'remove_single_nls' []: string -> string {
     str replace -r -a '(\n[\t ]*){2,}' '⏎'
     | str replace -arm '(?<!⏎)\n' ' ' # remove single line breaks used for code formatting
     | str replace -a '⏎' "\n\n"
@@ -192,18 +192,18 @@ export def 'remove_single_nls' [] {
 
 # Add newlines before and after text
 export def 'newlineit' [
-    $before
-    $after
-] {
+    before: int
+    after: int
+]: string -> string {
     $"((char nl) | str repeat $before)($in)((char nl) | str repeat $after)"
 }
 
 # Wrap text with decorative frame lines above and below
 export def 'frameit' [
-    $width_safe
-    $frame
-    $frame_color
-] {
+    width_safe: int
+    frame: string
+    frame_color: string
+]: string -> string {
     let input = $in
 
     $frame
@@ -215,9 +215,9 @@ export def 'frameit' [
 
 # Apply color and highlight *emphasized* text
 export def 'colorit' [
-    $highlight_color
-    $color
-] {
+    highlight_color: string
+    color: string
+]: string -> string {
     str replace -r -a '\*([^*]+?)\*' $'(ansi reset)(ansi $highlight_color)$1(ansi reset)(ansi $color)'
     | str c (ansi $color) $in (ansi reset)
 }
@@ -225,8 +225,8 @@ export def 'colorit' [
 # Align each line of text within specified width
 export def 'alignit' [
     alignment: string
-    width_safe
-] {
+    width_safe: int
+]: string -> string {
     lines
     | fill --alignment $alignment --width $width_safe
     | str join (char nl)
@@ -234,12 +234,12 @@ export def 'alignit' [
 
 # Add leading spaces to each line
 export def 'indentit' [
-    $indent
-] {
+    indent: int
+]: string -> string {
     str replace -arm '^' (char sp | str repeat $indent)
 }
 
-def 'nu-complete-colors' [] {
+def 'nu-complete-colors' []: nothing -> list<string> {
     ansi --list | take until {|it| $it.name == reset } | get name
 }
 
@@ -256,8 +256,8 @@ export def 'example' [
     --no-copy (-C) # Don't copy the output into clipboard
     --no-comment (-H) # Don't comment the result
     --abbreviated: int = 10
-    --external # Indicates that to execute this command one must use `nu -c` 
-] {
+    --external # Indicates that to execute this command one must use `nu -c`
+]: any -> string {
     let input = table --abbreviated $abbreviated
     | if $no_comment { } else { ansi strip }
 
@@ -283,7 +283,7 @@ export def 'example' [
     }
 }
 
-def get-last-commands-from-sql [n: int = 1] {
+def get-last-commands-from-sql [n: int = 1]: nothing -> any {
     open $nu.history-path
     | query db "select command_line from history order by id desc limit ?" -p [$n]
     | get command_line
@@ -303,7 +303,7 @@ def get-last-commands-from-sql [n: int = 1] {
 # [{a: 1, b: ""}, {b: 2, a: ""}]
 export def 'fill non-exist' [
     value_to_replace: any = ''
-] {
+]: table -> table {
     let table = $in
 
     $table
@@ -321,7 +321,7 @@ export def 'fill non-exist' [
 # Format `debug profile` output
 #
 # > debug profile {pin-text cyber} --max-depth 7 --spans | format profile | null
-export def 'format profile' [] {
+export def 'format profile' []: table -> table {
     skip
     | update depth {|i| $i.depth - 1 }
     | normalize duration_ms
@@ -351,7 +351,7 @@ export def --env gradient-screen [
     --no-date # Don't append date
     --echo
     --rows: int
-] {
+]: nothing -> any {
     let strings = $strings
     | if $in == [] {
         $env.gradient-screen?.texts?
@@ -424,7 +424,7 @@ export def --env gradient-screen [
 export def ls-git-modified-date [
     path?: path
     --max-files-in-commit: int = 5 # skip commits with more than this number of files. Useful for excluding automatic changes such as those by prettier or ruff
-] {
+]: nothing -> table {
     let path = $path | default { pwd }
 
     let gitlog = git log --all --format="===%ai" --name-only --diff-filter=ACMRT -- $path
@@ -458,7 +458,7 @@ export def ls-git-modified-date [
     try { $full_paths | update name { path relative-to (pwd) } } catch { $full_paths }
 }
 
-def split-ansi-chars [s: string] {
+def split-ansi-chars [s: string]: nothing -> list<string> {
     # Pattern to match: escape sequence + one character (no reset needed for gradients)
     let pat = "(\e\\[[0-9;]*m)+(.)"
 
@@ -470,15 +470,15 @@ def split-ansi-chars [s: string] {
     | compact --empty
 }
 
-def generate_colors [] { 1..3 | each { (random int 0..255) } }
+def generate_colors []: nothing -> list<int> { 1..3 | each { (random int 0..255) } }
 
-def make_hex [] { each { into binary --compact | encode hex } | prepend '0x' | str join }
+def make_hex []: list<int> -> string { each { into binary --compact | encode hex } | prepend '0x' | str join }
 
-def check_colors [c0 c1 --threshold = 250] {
+def check_colors [c0: list<int>, c1: list<int>, --threshold: int = 250]: nothing -> bool {
     ($c0 | zip $c1 | each {|i| ($i.0 - $i.1) ** 2 } | math sum | math sqrt) > $threshold
 }
 
-def rand_hex_col2 [] {
+def rand_hex_col2 []: nothing -> list<string> {
     # Try up to 30 times to find contrasting colors
     let pair = generate {|i=0|
         if $i >= 30 { return {} }
@@ -517,7 +517,7 @@ export def 'hist' [
     --cwd # Show only entries from the current folder
     --last-x: duration # Duration for the period to check commands
     --not-in-vd (-V) # Disable opening command in visidata
-] {
+]: nothing -> any {
     # Start building the SQL query
     let sql_query = "
         SELECT command_line as command, start_timestamp / 1000 as start_timestamp, session_id, hostname, cwd,
@@ -584,7 +584,7 @@ export def 'hist-to-script' [
     --up (-u): int = 0 # Set number of last events to save
     --all # Save all history into .nu file
     --directory-hist # Get history for a directory instead of session
-] {
+]: nothing -> nothing {
     let session = history session
 
     let filepath = $filename
@@ -625,7 +625,7 @@ export def 'hist-to-script' [
 # Convert data structure to JSON and open it in fx
 export def --wrapped in-fx [
     ...rest
-] {
+]: any -> nothing {
     to json -r
     | ansi strip
     | ^fx ...$rest
@@ -634,7 +634,7 @@ export def --wrapped in-fx [
 # Open data in Helix editor, return edited content to commandline
 export def 'in-hx' [
     --path (-p) # Output file path instead of content
-] {
+]: any -> nothing {
     let input = $in
     let type = $input | describe
     let filename = $nu.temp-path | path join (date now | format date "%Y%m%d_%H%M%S" | $in + '.nu')
@@ -670,7 +670,7 @@ use kv
 export def 'in-vd' [
     --json (-j) # Force using msgpack for piping data in-vd
     --csv (-c) # Force using csv for piping data in-vd
-] {
+]: any -> any {
     if ($in | describe | $in =~ 'FrameCustomValue') {
         polars into-nu
     } else { }
@@ -696,7 +696,7 @@ export def 'in-vd' [
 }
 
 # Open nushell commands history in visidata
-export def 'in-vd history' [] {
+export def 'in-vd history' []: table -> nothing {
     where command !~ 'in-vd history'
     | to csv
     | vd --save-filetype csv --filetype csv -o -
@@ -715,7 +715,7 @@ export def 'in-vd history' [] {
 # false
 # > [{a: {c: d}, b: e}] | has_hier
 # true
-def has_hier [] {
+def has_hier []: any -> bool {
     describe
     | find -r '^table(?!.*: (table|record|list))'
     | is-empty
@@ -779,7 +779,7 @@ export def --env ln-for-preview [
 export def --env mc [
     path1?: path
     path2?: path
-] {
+]: nothing -> nothing {
     let path = ($nu.temp-path | path join (random chars))
     if $path2 != null {
         ^mc --nosubshell $path1 $path2 -P $path
@@ -797,10 +797,10 @@ export def --env mc [
 ###file md.nu
 # Create directory and cd into it
 export def --env md [
-    target_dir
+    target_dir: string
     -d # Use standard directory
     --dest-dir: path = '/Users/user/temp'
-] {
+]: nothing -> nothing {
     let dir = (
         if $d or ($dest_dir != '/Users/user/temp') {
             $dest_dir | path join ($target_dir | str replace -a ' ' '_')
@@ -819,7 +819,7 @@ export def --env md [
 # Toggle suffix `_back` for a file
 export def 'mv1' [
     file: path
-] {
+]: nothing -> nothing {
     if ($file | str ends-with '_back') {
         mv $file $"($file | str replace -r '_back$' '')"
     } else {
@@ -831,7 +831,7 @@ export def 'mv1' [
 # Backup dotfiles and config directories to their git repos
 export def 'mygit log' [
     --message (-m): string
-] {
+]: nothing -> nothing {
     let message = $message
     | default (date now | format date "%Y-%m-%d")
 
@@ -863,7 +863,7 @@ export def 'mygit log' [
 }
 
 # Backup Nushell history database to timestamped SQL dump
-export def 'history-backup' [] {
+export def 'history-backup' []: nothing -> nothing {
     let hist_backups_dir = '~/.config/nushell/history-backups/'
     | path expand
 
@@ -896,9 +896,9 @@ export def 'history-backup' [] {
 # │ a │   │ a    │      │
 # ╰───┴───┴──────┴──────╯
 export def 'normalize' [
-    ...column_names
-    --suffix = '_norm'
-] {
+    ...column_names: string
+    --suffix: string = '_norm'
+]: table -> table {
     mut $table = ($in)
     let allowed_types = ['int' 'float' 'filesize']
 
@@ -930,7 +930,7 @@ export def 'nu-test install' [
     --cargo-test-path: path = '/Users/user/.cargo_test/'
     --plugin-config: path = '/Users/user/.test_config/nushell/polars_test.msgpackz'
     --pr: string # A PR to checkout like ayax79:polars_pivot
-] {
+]: nothing -> nothing {
     cd $nushell_repo_path
 
     git checkout main
@@ -962,7 +962,7 @@ export def 'nu-test install' [
 # Launch the test-installed Nushell binary
 export def 'nu-test launch' [
     --no-plugin
-] {
+]: nothing -> nothing {
     let exec = '/Users/user/.cargo_test/' | path join bin nu
     let params = [
         "--execute"
@@ -982,7 +982,7 @@ export def --env download-nushell-nightly [
     --arch (-a): string = 'aarch64-apple-darwin' # Architecture as specified in nushell/nightly repo
     --ext (-e): string = '.tar.gz' # Extension, including the leading dot (e.g. '.tar.gz')
     --destination-dir (-d): directory = $nightly_path # Destination directory in which to save the download
-] {
+]: nothing -> nothing {
     let most_recent_nightly = (http get https://api.github.com/repos/nushell/nightly/releases | get 0)
     let nightly_name = ($most_recent_nightly.name | str replace -r '^Nu-nightly-' '')
     let asset = http get $most_recent_nightly.assets_url
@@ -1005,7 +1005,7 @@ export def --env download-nushell-nightly [
 }
 
 # Launch the most recent downloaded nightly Nushell
-export def 'launch-downloaded' [] {
+export def 'launch-downloaded' []: nothing -> nothing {
     let path = glob ($nightly_path | path join *darwin *nu) | sort | last
     commandline edit -r $path
 }
@@ -1022,11 +1022,11 @@ export def 'launch-downloaded' [] {
 # ╰──────────────╯
 export def 'number-col-format' [
     column_name: string # A column name to format
-    --thousands-delim (-t) = '_' # Thousands delimiter: number-format 1000 -t ': 1'000
-    --decimals (-d) = 0 # Number of digits after decimal delimiter: number-format 1000.1234 -d 2: 1000.12
-    --denom (-D) = '' # Denom `--denom "Wt": number-format 1000 --denom 'Wt': 1000Wt
+    --thousands-delim (-t): string = '_' # Thousands delimiter: number-format 1000 -t ': 1'000
+    --decimals (-d): int = 0 # Number of digits after decimal delimiter: number-format 1000.1234 -d 2: 1000.12
+    --denom (-D): string = '' # Denom `--denom "Wt": number-format 1000 --denom 'Wt': 1000Wt
     --significant-digits: int = 0 # The number of first digits to display, others will become 0
-] {
+]: table -> table {
     let input = $in
 
     if $column_name not-in ($input | columns) {
@@ -1078,14 +1078,14 @@ export def 'number-col-format' [
 # > number-format 1000 --denom 'Wt'
 # 1_000Wt
 export def 'number-format' [
-    num? # Number to format
+    num?: number # Number to format
     --thousands-delim (-t): string = '_' # Thousands delimiter
     --integers (-i): int = 0 # Length of padding whole-part digits
     --significant-digits: int = 0 # The number of first digits to display, others will become 0
     --decimals (-d): int = 0 # Number of digits after decimal delimiter
     --denom (-D): string = '' # Denom
     --color: string = 'green'
-] {
+]: [int -> string float -> string nothing -> string] {
     let in_num = $in
 
     let parts = $num
@@ -1123,13 +1123,13 @@ export def 'number-format' [
 
 ###file orbita.nu
 # Generate 14 lines of spaces (placeholder grid)
-export def 'orbita' [] {
+export def 'orbita' []: nothing -> list<string> {
     1..14 | each { line ' ' }
 }
 
 def line [
     symbol: string
-] {
+]: nothing -> string {
     1..61 | each { $symbol } | str join
 }
 
@@ -1137,7 +1137,7 @@ def line [
 # An alternative to `inspect` that doesn't break debugging output
 export def 'print-and-pass' [
     callback?: closure
-] {
+]: any -> any {
     let input = $in
 
     if $callback == null {
@@ -1153,7 +1153,7 @@ export def 'print-and-pass' [
 # Create ramdisk in macOS
 export def 'ramdisk-create' [
     size: filesize = 4194304kb
-] {
+]: nothing -> nothing {
     let vol = (hdiutil attach -nobrowse -nomount $'ram://($size | into int | $in * 1.024 / 1000 * 2)' | str trim);
     sleep 2sec
     (^diskutil erasevolume HFS+ RAMDisk $vol)
@@ -1165,7 +1165,7 @@ export def 'ramdisk-create' [
 # by @melmass at discord
 
 # Interactively select columns from a table
-export def 'select-i' [] {
+export def 'select-i' []: table -> nothing {
     let tgt = $in
     let choices = $tgt
     | columns
@@ -1182,12 +1182,12 @@ export def 'select-i' [] {
 ###file side-by-side.nu
 # Display two tables side by side for comparison
 export def 'side-by-side' [
-    r # Right side table
+    r: any # Right side table
     --delimiter: string = ' ' # Separator between columns
     --collapse # Use compact table format
     --l-header: string # Left table header label
     --r-header: string # Right table header label
-] {
+]: any -> string {
     mut $l = $in | if $collapse { table } else { table -e } | into string | lines
     mut $r = $r | if $collapse { table } else { table -e } | into string | lines
 
@@ -1316,8 +1316,8 @@ alias std_prepend = prepend
 
 # Repeat a string n times
 export def 'str repeat' [
-    $n
-] {
+    n: int
+]: string -> string {
     let text = $in
     seq 1 $n | each { $text } | str join
 }
@@ -1331,7 +1331,7 @@ export def 'str append' [
     --tab (-t)
     --concatenator (-c): string = '' # Input and rest concatenator
     --rest-el: string = ' ' # Rest elements concatenator
-] {
+]: string -> string {
     let input = $in
     let concatenator = $"(
         if $new_line { (char nl) }
@@ -1357,7 +1357,7 @@ export def 'str prepend' [
     --tab (-t)
     --concatenator (-c): string = '' # Input and rest concatenator
     --rest-el: string = ' ' # Rest elements concatenator
-] {
+]: string -> string {
     let input = $in
     let concatenator = $"(
         if $new_line { (char nl) }
@@ -1375,13 +1375,13 @@ export def 'str prepend' [
 }
 
 # Add indentation to text (not implemented)
-export def 'indent' [] { }
+export def 'indent' []: string -> string { $in }
 
 # Remove indentation from text (not implemented)
-export def 'dedent' [] { }
+export def 'dedent' []: string -> string { $in }
 
 # Escape regex special characters in a string
-export def 'escape-regex' [] {
+export def 'escape-regex' []: string -> string {
     let input = $in
     let regex = '\.^$*+?{}()[]|/' | split chars | each { $'\($in)' } | str join '|' | $"\(($in))"
 
@@ -1389,13 +1389,13 @@ export def 'escape-regex' [] {
 }
 
 # Escape Nushell special characters for string interpolation
-export def 'escape-nushell-escapes' [] {
+export def 'escape-nushell-escapes' []: string -> string {
     str replace --all --regex '(\\|\"|\/|\(|\)|\{|\}|\$|\^|\#|\||\~)' '\$1'
 }
 
 ###file testcd.nu
 # Test helper for cd command
-export def --env 'testcd' [destination] { cd $destination }
+export def --env 'testcd' [destination: path]: nothing -> nothing { cd $destination }
 
 # Convert string to filesystem-safe filename
 export def 'to-safe-filename' [
@@ -1425,8 +1425,8 @@ export def 'to-safe-filename' [
 # used as the file content. If there is stdin closure takes the file name as an
 # argument & operates on it.
 export def 'to-temp-file' [
-    content? # Commands used to generate the content of the file.
-] {
+    content?: any # Commands used to generate the content of the file.
+]: [any -> path nothing -> path] {
     let content = if $content == null { } else { $content }
     let output_file = $nu.temp-path
     | path join $'(date now | into int).yaml'
@@ -1438,7 +1438,7 @@ export def 'to-temp-file' [
 
 ###file transcribe.nu
 # Transcribe audio file to text using whisper.cpp
-export def 'transcribe' [file: path] {
+export def 'transcribe' [file: path]: nothing -> nothing {
     let file = $file
     | if $in =~ '\.wav$' { } else {
         let f = $in + '.wav';
@@ -1460,7 +1460,7 @@ export def 'wez-to-ansi' [
     --regex: string = '^>' # Regex to separate prompts from outputs. Default is ''.
     --lines-before-top-of-term: int = 100 # Lines from top of scrollback in Wezterm to capture.
     --min-term-width: int = 0 # Minimum output width (pads with spaces)
-] {
+]: nothing -> string {
 
     # let regex = '^' + (ansi green_italic) + '>'
 
@@ -1483,7 +1483,7 @@ export def 'wez-to-ansi' [
 # Record Wezterm session to asciicast format
 export def 'wez-to-asciicast' [
     command: string = '' # Command to record
-    --filename: path # Output file path
+    --filename: path # Output file path (unused)
 ]: nothing -> path {
     let wezrec = ^wezterm record --cwd (pwd) -- $nu.current-exe --execute $'source $nu.env-path; clear; ($command)'
     | complete
@@ -1505,7 +1505,7 @@ export def 'wez-to-gif' [
     --filename: path # Output GIF path
     --font-family: string = "ZedMono Nerd Font" # Font for rendering
     --font-size: int = 20 # Font size in pixels
-] {
+]: nothing -> nothing {
 
     let wezrec = wez-to-asciicast
 
@@ -1534,7 +1534,7 @@ export def 'wez-to-gif' [
 export def 'wez-to-png' [
     n_last_commands: int = 2 # Number of recent commands (and outputs) to capture.
     --output-path: path = '' # Path for saving output images.
-] {
+]: nothing -> nothing {
     let output_path = $output_path
     | if $in != '' { } else {
         let filename = last-commands $n_last_commands
@@ -1557,12 +1557,12 @@ export def 'wez-to-png' [
     ^open -R $output_path
 }
 
-def now-fn []: nothing -> string {
+def 'now-fn' []: nothing -> string {
     date now | format date "%Y%m%d_%H%M%S"
 }
 
-def last-commands [
-    $n_last_commands
+def 'last-commands' [
+    n_last_commands: int
 ]: nothing -> string {
     history
     | last ($n_last_commands + 1)
@@ -1574,7 +1574,7 @@ def last-commands [
 
 # Helper function to get all unique directories from command history
 # Now with SQL-level filtering against dead_cwds
-def get-history-dirs [
+def 'get-history-dirs' [
     --include-dead (-d) # Include nonexistent directories in the results
 ]: nothing -> list<string> {
     # Ensure dead_cwds table exists
@@ -1599,13 +1599,13 @@ def get-history-dirs [
 }
 
 # Helper function to initialize dead_cwds table if it doesn't exist
-def init-dead-cwds-table []: nothing -> nothing {
+def 'init-dead-cwds-table' []: nothing -> nothing {
     open $nu.history-path
     | query db "CREATE TABLE IF NOT EXISTS dead_cwds (path TEXT PRIMARY KEY, added_date TEXT DEFAULT CURRENT_TIMESTAMP)"
 }
 
 # Helper function to add a dead directory to the table
-def add-dead-dir [
+def 'add-dead-dir' [
     dir: string # Directory to add to dead dirs list
 ]: nothing -> nothing {
     # Insert new directory if it doesn't exist (parameterized to prevent SQL injection)
@@ -1614,7 +1614,7 @@ def add-dead-dir [
 }
 
 # Scan history directories and rebuild the dead_cwds table with non-existent paths
-def update-dead-dirs []: nothing -> list<string> {
+def 'update-dead-dirs' []: nothing -> list<string> {
     # Get all directories including those already marked as dead
     let all_cwds = get-history-dirs --include-dead
 
@@ -1636,7 +1636,7 @@ def update-dead-dirs []: nothing -> list<string> {
 }
 
 # Find first existing path from candidates, recording dead ones along the way
-def find-first-existing [
+def 'find-first-existing' [
     candidates: list<string>
 ]: nothing -> string {
     $candidates
@@ -1653,7 +1653,7 @@ def find-first-existing [
 }
 
 # Select a directory path using fuzzy search
-def select-dir [
+def 'select-dir' [
     query: string # The search query
     --interactive (-i) # Force interactive mode
 ]: nothing -> string {
@@ -1680,20 +1680,20 @@ def select-dir [
 }
 
 # Helper function to get open Zellij tab names
-def zellij-tab-names []: nothing -> list<string> {
+def 'zellij-tab-names' []: nothing -> list<string> {
     if ($env.ZELLIJ? | is-empty) { return [] }
     zellij action query-tab-names | lines
 }
 
 # Generate regex pattern to match Zellij tab by directory name
 # Matches "dirname" or "dirname·2" (indexed duplicates)
-def zellij-tab-pattern [dir_name: string]: nothing -> string {
+def 'zellij-tab-pattern' [dir_name: string]: nothing -> string {
     $"^($dir_name)\(·|$\)"
 }
 
 # Handle Zellij tab navigation: create new tab, switch to existing, or rename current.
 # Returns true if caller should cd (Zellij renamed tab), false if Zellij handled navigation.
-def zellij-navigate [
+def 'zellij-navigate' [
     path: string # Target directory path
     dir_name: string # Directory name for tab
     --new-tab (-n) # Open in new tab
@@ -1754,7 +1754,7 @@ export def --env 'z' [
 }
 
 # Generate completions for z command from history
-export def 'nu-completions-cwds' [] {
+export def 'nu-completions-cwds' []: nothing -> record {
     # Using SQL-level filtering for completions as well
     init-dead-cwds-table
 
@@ -1809,13 +1809,13 @@ export def 'nu-completions-cwds' [] {
 
 # Find and replace text across multiple files by extension
 export def 'replace-in-all-files' [
-    find # Text to search for
-    replace # Replacement text
+    find: string # Text to search for
+    replace: string # Replacement text
     --quiet # Suppress statistics output
     --no-git-check # Skip uncommitted changes check
     --no-rg # Use Nushell instead of ripgrep
-    --extensions: list = [nu md py] # File extensions to process
-] {
+    --extensions: list<string> = [nu md py] # File extensions to process
+]: nothing -> any {
     let glob = $extensions
     | str join ','
     | str c '**/*.{' $in '}'
@@ -1858,7 +1858,7 @@ export def 'replace-in-all-files' [
 # Error if file has uncommitted git changes
 export def git-check-file-clean [
     file: path
-] {
+]: nothing -> nothing {
     let git_status = git status --porcelain -- $file
 
     if ($git_status | is-not-empty) {
@@ -1872,7 +1872,7 @@ export def git-check-file-clean [
 }
 
 # Insert new lines before the pipe symbol and let/mut
-def 'insert-new-lines' [] {
+def 'insert-new-lines' []: string -> string {
     let cmd = $in
 
     ast --flatten $cmd
@@ -1912,7 +1912,7 @@ export def 'nu-format' [
     } else { }
 }
 
-def nu-completions-files-modified [context: string] {
+def 'nu-completions-files-modified' [context: string]: nothing -> record {
     $context
     | split row ' '
     | last
@@ -1936,7 +1936,7 @@ def nu-completions-files-modified [context: string] {
 }
 
 # Resolve symlinks and return target paths, sorted by modification time
-export def 'fs' [...files: path@nu-completions-files-modified] {
+export def 'fs' [...files: path@nu-completions-files-modified]: nothing -> any {
     $files
     | uniq
     | each {|i|
@@ -1964,7 +1964,7 @@ export def 'fs' [...files: path@nu-completions-files-modified] {
 # Retrieve LLM conversation messages by hash suffix
 export def 'llm message' [
     ...rest: string@completion-llm-message
-] {
+]: nothing -> string {
     let dict = llm-open-log
 
     $rest
@@ -1979,7 +1979,7 @@ export def 'llm message' [
 }
 
 # Load and deduplicate LLM conversation log
-export def 'llm-open-log' [] {
+export def 'llm-open-log' []: nothing -> table {
     open ~/short_log.yaml
     | uniq-by content-hash
     | sort-by timestamp -r
@@ -1988,7 +1988,7 @@ export def 'llm-open-log' [] {
 # Generate completions for llm message command
 export def 'completion-llm-message' [
     --first: int = 200
-] {
+]: nothing -> record {
     llm-open-log
     | each {|i|
         $i.content
@@ -2012,7 +2012,7 @@ export def 'completion-llm-message' [
 
 # Concatenate rest parameters into a string
 @example escape-interpolation { 1 + 1 | str c 'result is ' $in } --result 'result is 2'
-export def 'str c' [...$rest] { $rest | into string | str join }
+export def 'str c' [...rest: any]: nothing -> string { $rest | into string | str join }
 
 # Helper function initially from nupm/utils/dirs.nu
 # 
@@ -2045,7 +2045,7 @@ export def --env cd-root [dir?: path]: [nothing -> nothing] {
 }
 
 # Preview text in all available figlet fonts
-export def figlet-demo [text: string] {
+export def figlet-demo [text: string]: nothing -> record {
     glob /opt/homebrew/Cellar/figlet/2.2.5/share/figlet/fonts/*.flf
     | par-each {|i|
         let i = $i
@@ -2059,7 +2059,7 @@ export def figlet-demo [text: string] {
 }
 
 # Rename Zellij tab, auto-incrementing duplicates
-export def rename-tab [name: string = ''] {
+export def rename-tab [name: string = '']: nothing -> nothing {
     let name = if $name == '' { pwd | path basename | str replace -r '^-+' '' } else { $name }
 
     let name_with_index = zellij action query-tab-names

--- a/nu-goodies/commands.nu
+++ b/nu-goodies/commands.nu
@@ -233,14 +233,6 @@ def 'nu-complete-colors' [] {
     ansi --list | take until {|it| $it.name == reset } | get name
 }
 
-###file dfr enumerate.nu
-export def 'dfr enumerate' [
-    n: int = 3
-] {
-    dfr first $n
-    | dfr into-nu
-    | enumerate
-}
 
 ###file example.nu
 # output a command from a pipe where `example` is used, and truncate the output table

--- a/nu-goodies/commands.nu
+++ b/nu-goodies/commands.nu
@@ -1615,7 +1615,7 @@ def update-dead-dirs []: nothing -> list<string> {
     | where {|dir| $dir | path exists | not $in }
 
     # Clear existing dead_cwds table and insert new values
-    init-dead-cwds-table
+    # (table already initialized by get-history-dirs above)
     open $nu.history-path
     | query db "DELETE FROM dead_cwds"
 

--- a/nu-goodies/commands.nu
+++ b/nu-goodies/commands.nu
@@ -1831,7 +1831,7 @@ export def 'replace-in-all-files' [
 
     let updated = $files_found
     | each {|i|
-        if not $no_git_check { check-clean-working-tree $i }
+        if not $no_git_check { git-check-file-clean $i }
 
         $i | open
         | str replace -a $find $replace
@@ -1851,23 +1851,16 @@ export def 'replace-in-all-files' [
 }
 
 # Error if file has uncommitted git changes
-export def 'check-clean-working-tree' [
-    $module_path: path
+export def git-check-file-clean [
+    $file: path
 ] {
-    cd ($module_path | path dirname)
+    let git_status = git status --short -- $file
 
-    let git_status = git status --short
-
-    $git_status
-    | lines
-    | parse '{s} {m} {f}'
-    | where f =~ $'($module_path | path basename)$'
-    | is-not-empty
-    | if $in {
+    if ($git_status | is-not-empty) {
         error make --unspanned {
             msg: (
-                "Working tree isn't empty. Please commit or stash changed files, " +
-                "or use `--no-git-check` flag. Uncommited files:\n" + $git_status
+                "File has uncommitted changes. Please commit or stash, " +
+                "or use `--no-git-check` flag.\n" + $git_status
             )
         }
     }

--- a/nu-goodies/commands.nu
+++ b/nu-goodies/commands.nu
@@ -1830,7 +1830,7 @@ export def 'replace-in-all-files' [
         }
         | compact
     } else {
-        rg $find --files-with-matches --glob $glob
+        rg $find --fixed-strings --files-with-matches --glob $glob
         | lines
     }
 

--- a/nu-goodies/commands.nu
+++ b/nu-goodies/commands.nu
@@ -1683,6 +1683,12 @@ def zellij-tab-names []: nothing -> list<string> {
     zellij action query-tab-names | lines
 }
 
+# Generate regex pattern to match Zellij tab by directory name
+# Matches "dirname" or "dirname·2" (indexed duplicates)
+def zellij-tab-pattern [dir_name: string]: nothing -> string {
+    $"^($dir_name)\(·|$\)"
+}
+
 # Returns true if caller should cd, false if Zellij handled navigation
 def zellij-need-cd [
     $path: string # Target directory path
@@ -1699,7 +1705,7 @@ def zellij-need-cd [
 
     # Check if tab with this name already exists
     let matching_tab = zellij-tab-names
-    | where { $in =~ $"^($dir_name)\(·|$\)" }
+    | where { $in =~ (zellij-tab-pattern $dir_name) }
     | get 0?
 
     if ($matching_tab | is-not-empty) and ([true false] | input list 'switch to tab') {
@@ -1800,7 +1806,7 @@ export def 'nu-completions-cwds' [] {
 
         # Check if a Zellij tab exists for this directory
         let dir_name = $row.cwd | path split | last | str replace '"' ''
-        let has_tab = $zellij_tabs | any { $in =~ $"^($dir_name)\(·|$$\)" }
+        let has_tab = $zellij_tabs | any { $in =~ (zellij-tab-pattern $dir_name) }
 
         if $has_tab { $"⇆ ($timestamp)" } else { $timestamp }
     }

--- a/nu-goodies/commands.nu
+++ b/nu-goodies/commands.nu
@@ -479,23 +479,28 @@ def check_colors [c0 c1 --threshold = 250] {
 }
 
 def rand_hex_col2 [] {
-    mut color0 = []
-    mut color1 = []
+    # Try up to 30 times to find contrasting colors
+    let pair = generate {|i=0|
+        if $i >= 30 { return {} }
 
-    for pair in 1..30 {
-        $color0 = (generate_colors)
-        $color1 = (generate_colors)
-        if (check_colors $color0 $color1) {
-            break
+        let c0 = generate_colors
+        let c1 = generate_colors
+
+        if (check_colors $c0 $c1) {
+            {out: [$c0 $c1]}
+        } else {
+            {next: ($i + 1)}
         }
     }
+    | get 0?
 
-    if not (check_colors $color0 $color1) {
+    # Fallback: force contrast if no good pair found
+    $pair | default {
+        let c0 = generate_colors
         let rand = random int 100..180
-        $color1 = ($color0 | each { ($in + $rand) mod 255 })
+        [$c0 ($c0 | each { ($in + $rand) mod 255 })]
     }
-
-    [$color0 $color1] | each { make_hex }
+    | each { make_hex }
 }
 
 ###file hist.nu

--- a/nu-goodies/commands.nu
+++ b/nu-goodies/commands.nu
@@ -1580,15 +1580,6 @@ def add-dead-dir [
     | query db "INSERT OR IGNORE INTO dead_cwds (path) VALUES (?)" -p [$dir]
 }
 
-# Helper function to remove a directory from dead dirs
-def remove-dead-dir [
-    $dir: string # Directory to remove from dead dirs list
-]: nothing -> nothing {
-    # Delete the directory (parameterized to prevent SQL injection)
-    open $nu.history-path
-    | query db "DELETE FROM dead_cwds WHERE path = ?" -p [$dir]
-}
-
 # Scan history directories and rebuild the dead_cwds table with non-existent paths
 def update-dead-dirs []: nothing -> list<string> {
     # Get all directories including those already marked as dead
@@ -1704,32 +1695,11 @@ export def --env 'z' [
     --interactive (-i) # Force interactive mode
     --new-tab (-n) # Open directory in a new Zellij tab
     --update-dead-dirs (-u) # Refresh the list of nonexistent directories
-    --clean (-c) # Remove directories from dead list that now exist
 ]: nothing -> nothing {
     # Handle update dead dirs
     if $update_dead_dirs {
         print "Updating dead directories list..."
         update-dead-dirs
-        return
-    }
-
-    # Handle cleaning dead dirs that now exist
-    if $clean {
-        init-dead-cwds-table
-        let dead_dirs = open $nu.history-path | query db "SELECT path FROM dead_cwds" | get path
-        let existing_dirs = $dead_dirs | where {|dir| $dir | path exists }
-
-        if ($existing_dirs | is-empty) {
-            print "No directories to clean from the dead list."
-            return
-        }
-
-        # Remove existing dirs from dead list
-        $existing_dirs | each {|dir|
-            remove-dead-dir $dir
-            print $"Removed ($dir) from dead directories list"
-        }
-
         return
     }
 

--- a/nu-goodies/commands.nu
+++ b/nu-goodies/commands.nu
@@ -1702,10 +1702,9 @@ def handle-zellij [
     | where { $in =~ $"^($dir_name)\(·|$\)" }
     | get 0?
 
-    if ($matching_tab | is-not-empty) {
+    if ($matching_tab | is-not-empty) and ([true false] | input list 'switch to tab') {
         # Switch to existing tab
         zellij action go-to-tab-name $matching_tab
-        print -n 'Switching to tab ' $matching_tab
     } else {
         # Rename current tab
         zellij action rename-tab $dir_name

--- a/nu-goodies/commands.nu
+++ b/nu-goodies/commands.nu
@@ -1634,66 +1634,46 @@ def handle-dead-dirs [
     }
 }
 
-# Helper function to get valid directory paths
-# Now using SQL filtering instead of Nushell filtering
-def get-valid-dirs [
-    --update-dead (-u) # Update dead directories before filtering
-]: nothing -> string {
-    if $update_dead {
-        # Update dead directories first
-        handle-dead-dirs --update=true | ignore
-    }
-
-    # Get valid directories with SQL-level filtering
-    get-history-dirs
-    | to text
-}
-
 # Helper function to select a directory path
 def select-dir [
     $query: string # The search query
     --interactive (-i) # Force interactive mode
 ]: nothing -> string {
-    let valid_cwds = get-valid-dirs
-
-    # Function for interactive selection
-    let select_interactive = {
-        $valid_cwds | fzf --scheme=path -q $query
-    }
+    # Get valid directories with SQL-level filtering
+    let valid_cwds = get-history-dirs | to text
 
     if ($query | path exists) {
         # Direct path exists - use it
-        $query
-    } else if $interactive {
+        return $query
+    }
+
+    if $interactive {
         # Interactive mode requested
-        do $select_interactive
-    } else {
-        # Try fuzzy finding and return first existing directory
-        let fuzzy_results = $valid_cwds
-        | fzf -f $query
-        | lines
+        return ($valid_cwds | fzf --scheme=path -q $query)
+    }
 
-        # Find the first result that actually exists
-        let existing_path = $fuzzy_results
-        | first 10
-        | par-each --keep-order {|path|
-            if ($path | path exists) {
-                $path
-            } else {
-                # Add non-existing dir to dead dirs list
-                add-dead-dir $path
-                null
-            }
-        }
-        | compact
-        | get 0?
-
-        if ($existing_path | is-empty) {
-            # No valid match found - fall back to interactive
-            do $select_interactive
+    # Try fuzzy finding and return first existing directory
+    let existing_path = $valid_cwds
+    | fzf -f $query
+    | lines
+    | first 10
+    | par-each --keep-order {|path|
+        if ($path | path exists) {
+            $path
         } else {
-            $existing_path
+            # Add non-existing dir to dead dirs list
+            add-dead-dir $path
+            null
         }
+    }
+    | compact
+    | get 0?
+
+    if ($existing_path | is-empty) {
+        # No valid match found - fall back to interactive
+        $valid_cwds | fzf --scheme=path -q $query
+    } else {
+        $existing_path
     }
 }
 
@@ -1703,32 +1683,29 @@ def handle-zellij [
     $dir_name: string # Directory name for tab
     --new-tab (-n) # Open in new tab
 ]: nothing -> bool {
-    if ($env.ZELLIJ? | is-empty) {
-        return false
-    }
+    if ($env.ZELLIJ? | is-empty) { return false }
 
     if $new_tab {
         # Create new tab with the directory
         zellij action new-tab --layout default --cwd $path --name $dir_name
-        true
-    } else {
-        # Check if tab with this name already exists
-        let existing_tabs = zellij action query-tab-names | lines
-
-        $existing_tabs
-        | where $it =~ $"^($dir_name)\(·|$)"
-        | if $in != [] {
-            # Switch to existing tab
-            let name = first
-
-            zellij action go-to-tab-name $name
-            print -n 'Switching to tab ' $name
-        } else {
-            # Rename current tab
-            zellij action rename-tab $dir_name
-        }
-        false
+        return true
     }
+
+    # Check if tab with this name already exists
+    let matching_tab = zellij action query-tab-names
+    | lines
+    | where { $in =~ $"^($dir_name)\(·|$\)" }
+    | get 0?
+
+    if ($matching_tab | is-not-empty) {
+        # Switch to existing tab
+        zellij action go-to-tab-name $matching_tab
+        print -n 'Switching to tab ' $matching_tab
+    } else {
+        # Rename current tab
+        zellij action rename-tab $dir_name
+    }
+    false
 }
 
 # Main z command
@@ -1765,33 +1742,8 @@ export def --env 'z' [
         return
     }
 
-    # Handle case when no query is provided
-    if ($query | is-empty) {
-        # Default to interactive mode
-        let target_path = select-dir "" --interactive=true
-
-        # Exit if no path was selected
-        if ($target_path | is-empty) { return }
-
-        # Expand the path to full format
-        let expanded_path = $target_path | path expand
-
-        # Get directory name for tab naming
-        let dir_name = $target_path | path split | last
-
-        # Handle Zellij integration
-        let zellij_handled = handle-zellij $expanded_path $dir_name --new-tab=$new_tab
-
-        # Change to the target directory if not handled by Zellij new tab
-        if not $zellij_handled {
-            cd $expanded_path
-        }
-
-        return
-    }
-
-    # Get target path with query
-    let target_path = select-dir $query --interactive=$interactive
+    # Get target path - default to interactive mode when no query
+    let target_path = select-dir ($query | default "") --interactive=($interactive or ($query | is-empty))
 
     # Exit if no path was selected
     if ($target_path | is-empty) { return }
@@ -1803,10 +1755,8 @@ export def --env 'z' [
     let dir_name = $target_path | path split | last
 
     # Handle Zellij integration
-    let zellij_handled = handle-zellij $expanded_path $dir_name --new-tab=$new_tab
-
     # Change to the target directory if not handled by Zellij new tab
-    if not $zellij_handled {
+    if not (handle-zellij $expanded_path $dir_name --new-tab=$new_tab) {
         cd $expanded_path
     }
 }

--- a/nu-goodies/commands.nu
+++ b/nu-goodies/commands.nu
@@ -1705,10 +1705,11 @@ def handle-zellij [
     if ($matching_tab | is-not-empty) and ([true false] | input list 'switch to tab') {
         # Switch to existing tab
         zellij action go-to-tab-name $matching_tab
-    } else {
-        # Rename current tab
-        zellij action rename-tab $dir_name
+        return true
     }
+
+    # Rename current tab
+    zellij action rename-tab $dir_name
     false
 }
 

--- a/nu-goodies/commands.nu
+++ b/nu-goodies/commands.nu
@@ -1588,9 +1588,9 @@ def add-dead-dir [
     # Ensure table exists
     init-dead-cwds-table
 
-    # Insert new directory if it doesn't exist
+    # Insert new directory if it doesn't exist (parameterized to prevent SQL injection)
     open $nu.history-path
-    | query db $"INSERT OR IGNORE INTO dead_cwds \(path\) VALUES \('($dir)'\)"
+    | query db "INSERT OR IGNORE INTO dead_cwds (path) VALUES (?)" -p [$dir]
 }
 
 # Helper function to remove a directory from dead dirs
@@ -1600,9 +1600,9 @@ def remove-dead-dir [
     # Ensure table exists
     init-dead-cwds-table
 
-    # Delete the directory
+    # Delete the directory (parameterized to prevent SQL injection)
     open $nu.history-path
-    | query db $"DELETE FROM dead_cwds WHERE path = '($dir)'"
+    | query db "DELETE FROM dead_cwds WHERE path = ?" -p [$dir]
 }
 
 # Helper function to handle dead directories

--- a/nu-goodies/commands.nu
+++ b/nu-goodies/commands.nu
@@ -1570,24 +1570,11 @@ def init-dead-cwds-table []: nothing -> nothing {
     | query db "CREATE TABLE IF NOT EXISTS dead_cwds (path TEXT PRIMARY KEY, added_date TEXT DEFAULT CURRENT_TIMESTAMP)"
 }
 
-# Helper function to read dead directories from SQLite
-def read-dead-dirs []: nothing -> list<string> {
-    # Ensure table exists
-    init-dead-cwds-table
-
-    # Get all dead directories
-    open $nu.history-path
-    | query db "SELECT path FROM dead_cwds"
-    | get path
-}
 
 # Helper function to add a dead directory to the table
 def add-dead-dir [
     $dir: string # Directory to add to dead dirs list
 ]: nothing -> nothing {
-    # Ensure table exists
-    init-dead-cwds-table
-
     # Insert new directory if it doesn't exist (parameterized to prevent SQL injection)
     open $nu.history-path
     | query db "INSERT OR IGNORE INTO dead_cwds (path) VALUES (?)" -p [$dir]
@@ -1597,9 +1584,6 @@ def add-dead-dir [
 def remove-dead-dir [
     $dir: string # Directory to remove from dead dirs list
 ]: nothing -> nothing {
-    # Ensure table exists
-    init-dead-cwds-table
-
     # Delete the directory (parameterized to prevent SQL injection)
     open $nu.history-path
     | query db "DELETE FROM dead_cwds WHERE path = ?" -p [$dir]
@@ -1731,7 +1715,8 @@ export def --env 'z' [
 
     # Handle cleaning dead dirs that now exist
     if $clean {
-        let dead_dirs = read-dead-dirs
+        init-dead-cwds-table
+        let dead_dirs = open $nu.history-path | query db "SELECT path FROM dead_cwds" | get path
         let existing_dirs = $dead_dirs | where {|dir| $dir | path exists }
 
         if ($existing_dirs | is-empty) {

--- a/nu-goodies/commands.nu
+++ b/nu-goodies/commands.nu
@@ -233,7 +233,6 @@ def 'nu-complete-colors' [] {
     ansi --list | take until {|it| $it.name == reset } | get name
 }
 
-
 ###file example.nu
 # output a command from a pipe where `example` is used, and truncate the output table
 #
@@ -527,8 +526,7 @@ export def 'hist' [
         append $" AND start_timestamp > ((date now) - $last_x | into int)" # Convert to nanoseconds
     } else { }
     | append ' ORDER BY id DESC'
-    | if not ($all or $entries == 0) {
-        # Apply limit if not --all
+    | if not ($all or $entries == 0 or $like_filter != null) {
         append $" LIMIT ($entries)"
     } else { }
     | str join

--- a/nu-goodies/commands.nu
+++ b/nu-goodies/commands.nu
@@ -224,8 +224,8 @@ export def 'colorit' [
 
 # Align each line of text within specified width
 export def 'alignit' [
-    $alignment: string
-    $width_safe
+    alignment: string
+    width_safe
 ] {
     lines
     | fill --alignment $alignment --width $width_safe
@@ -895,7 +895,7 @@ export def 'normalize' [
     --suffix = '_norm'
 ] {
     mut $table = ($in)
-    let $allowed_types = ['int' 'float' 'filesize']
+    let allowed_types = ['int' 'float' 'filesize']
 
     for column in $column_names {
         let max_value = $table
@@ -1451,7 +1451,7 @@ export def 'transcribe' [file: path] {
 ###file wez-to-ansi.nu
 # Capture recent commands from Wezterm scrollback with ANSI codes
 export def 'wez-to-ansi' [
-    $n_last_commands: int = 2 # Number of recent commands (and outputs) to capture.
+    n_last_commands: int = 2 # Number of recent commands (and outputs) to capture.
     --regex: string = '^>' # Regex to separate prompts from outputs. Default is ''.
     --lines_before_top_of_term: int = 100 # Lines from top of scrollback in Wezterm to capture.
     --min_term_width: int = 0 # Minimum output width (pads with spaces)
@@ -1527,7 +1527,7 @@ export def 'wez-to-gif' [
 
 # Capture wezterm scrollback, split by prompts, output chosen ones to an image file
 export def 'wez-to-png' [
-    $n_last_commands: int = 2 # Number of recent commands (and outputs) to capture.
+    n_last_commands: int = 2 # Number of recent commands (and outputs) to capture.
     --output_path: path = '' # Path for saving output images.
 ] {
     let output_path = $output_path
@@ -1601,7 +1601,7 @@ def init-dead-cwds-table []: nothing -> nothing {
 
 # Helper function to add a dead directory to the table
 def add-dead-dir [
-    $dir: string # Directory to add to dead dirs list
+    dir: string # Directory to add to dead dirs list
 ]: nothing -> nothing {
     # Insert new directory if it doesn't exist (parameterized to prevent SQL injection)
     open $nu.history-path
@@ -1649,7 +1649,7 @@ def find-first-existing [
 
 # Select a directory path using fuzzy search
 def select-dir [
-    $query: string # The search query
+    query: string # The search query
     --interactive (-i) # Force interactive mode
 ]: nothing -> string {
     let valid_cwds = get-history-dirs | to text
@@ -1852,7 +1852,7 @@ export def 'replace-in-all-files' [
 
 # Error if file has uncommitted git changes
 export def git-check-file-clean [
-    $file: path
+    file: path
 ] {
     let git_status = git status --short -- $file
 
@@ -1868,7 +1868,7 @@ export def git-check-file-clean [
 
 # Insert new lines before the pipe symbol and let/mut
 def 'insert-new-lines' [] {
-    let $cmd = $in
+    let cmd = $in
 
     ast --flatten $cmd
     | where {|it| $it.shape == shape_pipe or ($it.shape == 'shape_internalcall' and $it.content in [let mut]) }
@@ -2043,7 +2043,7 @@ export def --env cd-root [dir?: path]: [nothing -> nothing] {
 export def figlet-demo [text: string] {
     glob /opt/homebrew/Cellar/figlet/2.2.5/share/figlet/fonts/*.flf
     | par-each {|i|
-        let $i = $i
+        let i = $i
         | path basename;
 
         $text

--- a/nu-goodies/commands.nu
+++ b/nu-goodies/commands.nu
@@ -1677,6 +1677,12 @@ def select-dir [
     }
 }
 
+# Helper function to get open Zellij tab names
+def zellij-tab-names []: nothing -> list<string> {
+    if ($env.ZELLIJ? | is-empty) { return [] }
+    zellij action query-tab-names | lines
+}
+
 # Helper function to handle Zellij integration
 def handle-zellij [
     $path: string # Target directory path
@@ -1692,8 +1698,7 @@ def handle-zellij [
     }
 
     # Check if tab with this name already exists
-    let matching_tab = zellij action query-tab-names
-    | lines
+    let matching_tab = zellij-tab-names
     | where { $in =~ $"^($dir_name)\(·|$\)" }
     | get 0?
 
@@ -1766,6 +1771,10 @@ export def 'nu-completions-cwds' [] {
     init-dead-cwds-table
 
     let termsize = term size | get columns | $in - 5
+    let max_depth = 6
+
+    # Get open Zellij tabs for marking
+    let zellij_tabs = zellij-tab-names
 
     let variants = open $nu.history-path
     | query db "SELECT h.cwd, MAX(h.start_timestamp) as last_timestamp
@@ -1784,8 +1793,19 @@ export def 'nu-completions-cwds' [] {
         }
         | if ($in has ' ') { $'"($in)"' } else { $in }
     }
+    # Filter by depth - skip paths deeper than max_depth
+    | where { $in.cwd | path split | length | $in <= $max_depth }
+    # Filter by length
     | where ($it.cwd | str length --grapheme-clusters) < $termsize
-    | update last_timestamp { into int | $in / 1000 | into int | into datetime -f '%s' | date humanize }
+    | update last_timestamp {|row|
+        let timestamp = $row.last_timestamp | into int | $in / 1000 | into int | into datetime -f '%s' | date humanize
+
+        # Check if a Zellij tab exists for this directory
+        let dir_name = $row.cwd | path split | last | str replace '"' ''
+        let has_tab = $zellij_tabs | any { $in =~ $"^($dir_name)\(·|$$\)" }
+
+        if $has_tab { $"⇆ ($timestamp)" } else { $timestamp }
+    }
     | rename value description
 
     {

--- a/nu-goodies/commands.nu
+++ b/nu-goodies/commands.nu
@@ -1689,8 +1689,9 @@ def zellij-tab-pattern [dir_name: string]: nothing -> string {
     $"^($dir_name)\(·|$\)"
 }
 
-# Returns true if caller should cd, false if Zellij handled navigation
-def zellij-need-cd [
+# Handle Zellij tab navigation: create new tab, switch to existing, or rename current.
+# Returns true if caller should cd (Zellij renamed tab), false if Zellij handled navigation.
+def zellij-navigate [
     $path: string # Target directory path
     $dir_name: string # Directory name for tab
     --new-tab (-n) # Open in new tab
@@ -1765,7 +1766,7 @@ export def --env 'z' [
     # Get directory name for tab naming
     let dir_name = $target_path | path split | last
 
-    if (zellij-need-cd $expanded_path $dir_name --new-tab=$new_tab) {
+    if (zellij-navigate $expanded_path $dir_name --new-tab=$new_tab) {
         cd $expanded_path
     }
 }

--- a/nu-goodies/commands.nu
+++ b/nu-goodies/commands.nu
@@ -8,7 +8,7 @@ export def 'L' [
 }
 
 ###file O.nu
-def nu-complete-macos-apps []: nothing -> list<string> {
+def completions-macos-apps []: nothing -> list<string> {
     ls /Applications -s | get name | each { str replace '.app' '' | $'"($in)"' }
 }
 
@@ -16,7 +16,7 @@ def nu-complete-macos-apps []: nothing -> list<string> {
 # > O O.nu --app "Sublime Text"
 export def 'O' [
     filepath?: path
-    --app (-a): string@'nu-complete-macos-apps' = 'Snagit 2022.app' # App to open with
+    --app (-a): string@'completions-macos-apps' = 'Snagit 2022.app' # App to open with
     --reveal (-r) # Reveal app in Finder
 ]: [path -> nothing nothing -> nothing] {
     if $filepath == null { } else { $filepath }
@@ -127,9 +127,9 @@ export def 'copy-cmd' []: nothing -> nothing {
 # Print a string colorfully with bells and whistles
 export def 'cprint' [
     text?: string # Text to format, if omitted stdin will be used
-    --color (-c): string@'nu-complete-colors' = 'default' # Color to use for the cprint text
-    --highlight-color (-H): string@'nu-complete-colors' = 'green_bold' # Color to use for highlighting text enclosed in asterisks
-    --frame-color (-r): string@'nu-complete-colors' = 'dark_gray' # Color to use for frame
+    --color (-c): string@'completions-colors' = 'default' # Color to use for the cprint text
+    --highlight-color (-H): string@'completions-colors' = 'green_bold' # Color to use for highlighting text enclosed in asterisks
+    --frame-color (-r): string@'completions-colors' = 'dark_gray' # Color to use for frame
     --frame (-f): string = '' # Symbol (or a string) to frame a text
     --lines-before (-b): int = 0 # Number of new lines before a text
     --lines-after (-a): int = 1 # Number of new lines after a text
@@ -239,7 +239,7 @@ export def 'indentit' [
     str replace -arm '^' (char sp | str repeat $indent)
 }
 
-def 'nu-complete-colors' []: nothing -> list<string> {
+def 'completions-colors' []: nothing -> list<string> {
     ansi --list | take until {|it| $it.name == reset } | get name
 }
 
@@ -1724,7 +1724,7 @@ def 'zellij-navigate' [
 
 # Jump to directory from history using fuzzy search
 export def --env 'z' [
-    query?: string@'nu-completions-cwds' # Fuzzy search query for directory
+    query?: string@'completions-cwds' # Fuzzy search query for directory
     --interactive (-i) # Always show interactive picker
     --new-tab (-n) # Open in new Zellij tab
     --update-dead-dirs (-u) # Rebuild nonexistent directories cache
@@ -1754,7 +1754,7 @@ export def --env 'z' [
 }
 
 # Generate completions for z command from history
-export def 'nu-completions-cwds' []: nothing -> record {
+export def 'completions-cwds' []: nothing -> record {
     # Using SQL-level filtering for completions as well
     init-dead-cwds-table
 
@@ -1912,7 +1912,7 @@ export def 'nu-format' [
     } else { }
 }
 
-def 'nu-completions-files-modified' [context: string]: nothing -> record {
+def 'completions-files-modified' [context: string]: nothing -> record {
     $context
     | split row ' '
     | last
@@ -1936,7 +1936,7 @@ def 'nu-completions-files-modified' [context: string]: nothing -> record {
 }
 
 # Resolve symlinks and return target paths, sorted by modification time
-export def 'fs' [...files: path@nu-completions-files-modified]: nothing -> any {
+export def 'fs' [...files: path@completions-files-modified]: nothing -> any {
     $files
     | uniq
     | each {|i|
@@ -1963,7 +1963,7 @@ export def 'fs' [...files: path@nu-completions-files-modified]: nothing -> any {
 
 # Retrieve LLM conversation messages by hash suffix
 export def 'llm message' [
-    ...rest: string@completion-llm-message
+    ...rest: string@completions-llm-message
 ]: nothing -> string {
     let dict = llm-open-log
 
@@ -1986,7 +1986,7 @@ export def 'llm-open-log' []: nothing -> table {
 }
 
 # Generate completions for llm message command
-export def 'completion-llm-message' [
+export def 'completions-llm-message' [
     --first: int = 200
 ]: nothing -> record {
     llm-open-log

--- a/nu-goodies/commands.nu
+++ b/nu-goodies/commands.nu
@@ -1627,43 +1627,44 @@ def update-dead-dirs []: nothing -> list<string> {
     $dead_cwds
 }
 
-# Helper function to select a directory path
-def select-dir [
-    $query: string # The search query
-    --interactive (-i) # Force interactive mode
+# Find first existing path from candidates, recording dead ones along the way
+def find-first-existing [
+    candidates: list<string>
 ]: nothing -> string {
-    # Get valid directories with SQL-level filtering
-    let valid_cwds = get-history-dirs | to text
-
-    if ($query | path exists) {
-        # Direct path exists - use it
-        return $query
-    }
-
-    if $interactive {
-        # Interactive mode requested
-        return ($valid_cwds | fzf --scheme=path -q $query)
-    }
-
-    # Try fuzzy finding and return first existing directory
-    let existing_path = $valid_cwds
-    | fzf -f $query
-    | lines
-    | first 10
+    $candidates
     | par-each --keep-order {|path|
         if ($path | path exists) {
             $path
         } else {
-            # Add non-existing dir to dead dirs list
             add-dead-dir $path
             null
         }
     }
     | compact
     | get 0?
+}
+
+# Select a directory path using fuzzy search
+def select-dir [
+    $query: string # The search query
+    --interactive (-i) # Force interactive mode
+]: nothing -> string {
+    let valid_cwds = get-history-dirs | to text
+
+    if ($query | path exists) {
+        return $query
+    }
+
+    if $interactive {
+        return ($valid_cwds | fzf --scheme=path -q $query)
+    }
+
+    # Try fuzzy finding first
+    let candidates = $valid_cwds | fzf -f $query | lines | first 10
+    let existing_path = find-first-existing $candidates
 
     if ($existing_path | is-empty) {
-        # No valid match found - fall back to interactive
+        # Fall back to interactive
         $valid_cwds | fzf --scheme=path -q $query
     } else {
         $existing_path

--- a/nu-goodies/commands.nu
+++ b/nu-goodies/commands.nu
@@ -177,14 +177,14 @@ export def 'wrapit' [
     indent: int
 ]: string -> string {
     str replace -arm '^[\t ]+' ''
-    | if $keep_single_breaks { } else { remove_single_nls }
+    | if $keep_single_breaks { } else { remove-single-nls }
     | str replace -arm '[\t ]+$' ''
     | str replace -arm $"\(.{1,($width_safe)}\)\(\\s|$\)|\(.{1,($width_safe)}\)" "$1$3\n"
     | str replace -r $'\s+$' '' # trailing new line
 }
 
 # Collapse single newlines into spaces, preserve double newlines as paragraphs
-export def 'remove_single_nls' []: string -> string {
+export def 'remove-single-nls' []: string -> string {
     str replace -r -a '(\n[\t ]*){2,}' '⏎'
     | str replace -arm '(?<!⏎)\n' ' ' # remove single line breaks used for code formatting
     | str replace -a '⏎' "\n\n"
@@ -374,7 +374,7 @@ export def --env gradient-screen [
     let 1_len = $1_list | length
     let date_text = date now | format date "%Y%m%d_%H%M%S"
 
-    let colors = rand_hex_col2
+    let colors = rand-hex-col2
 
     $env.gradient-screen-last-colors = $colors
 
@@ -470,23 +470,23 @@ def split-ansi-chars [s: string]: nothing -> list<string> {
     | compact --empty
 }
 
-def generate_colors []: nothing -> list<int> { 1..3 | each { (random int 0..255) } }
+def generate-colors []: nothing -> list<int> { 1..3 | each { (random int 0..255) } }
 
-def make_hex []: list<int> -> string { each { into binary --compact | encode hex } | prepend '0x' | str join }
+def make-hex []: list<int> -> string { each { into binary --compact | encode hex } | prepend '0x' | str join }
 
-def check_colors [c0: list<int>, c1: list<int>, --threshold: int = 250]: nothing -> bool {
+def check-colors [c0: list<int>, c1: list<int>, --threshold: int = 250]: nothing -> bool {
     ($c0 | zip $c1 | each {|i| ($i.0 - $i.1) ** 2 } | math sum | math sqrt) > $threshold
 }
 
-def rand_hex_col2 []: nothing -> list<string> {
+def rand-hex-col2 []: nothing -> list<string> {
     # Try up to 30 times to find contrasting colors
     let pair = generate {|i=0|
         if $i >= 30 { return {} }
 
-        let c0 = generate_colors
-        let c1 = generate_colors
+        let c0 = generate-colors
+        let c1 = generate-colors
 
-        if (check_colors $c0 $c1) {
+        if (check-colors $c0 $c1) {
             {out: [$c0 $c1]}
         } else {
             {next: ($i + 1)}
@@ -496,11 +496,11 @@ def rand_hex_col2 []: nothing -> list<string> {
 
     # Fallback: force contrast if no good pair found
     $pair | default {
-        let c0 = generate_colors
+        let c0 = generate-colors
         let rand = random int 100..180
         [$c0 ($c0 | each { ($in + $rand) mod 255 })]
     }
-    | each { make_hex }
+    | each { make-hex }
 }
 
 ###file hist.nu

--- a/nu-goodies/commands.nu
+++ b/nu-goodies/commands.nu
@@ -1570,7 +1570,6 @@ def init-dead-cwds-table []: nothing -> nothing {
     | query db "CREATE TABLE IF NOT EXISTS dead_cwds (path TEXT PRIMARY KEY, added_date TEXT DEFAULT CURRENT_TIMESTAMP)"
 }
 
-
 # Helper function to add a dead directory to the table
 def add-dead-dir [
     $dir: string # Directory to add to dead dirs list
@@ -1661,8 +1660,8 @@ def zellij-tab-pattern [dir_name: string]: nothing -> string {
 # Handle Zellij tab navigation: create new tab, switch to existing, or rename current.
 # Returns true if caller should cd (Zellij renamed tab), false if Zellij handled navigation.
 def zellij-navigate [
-    $path: string # Target directory path
-    $dir_name: string # Directory name for tab
+    path: string # Target directory path
+    dir_name: string # Directory name for tab
     --new-tab (-n) # Open in new tab
 ]: nothing -> bool {
     if ($env.ZELLIJ? | is-empty) { return true }
@@ -1745,7 +1744,7 @@ export def 'nu-completions-cwds' [] {
             '' => '~'
             $relative_pwd => ([~ $relative_pwd] | path join)
         }
-        | if ($in has ' ') { $'"($in)"' } else { $in }
+        | if ($in has ' ') { $'"($in)"' } else { }
     }
     # Filter by depth - skip paths deeper than max_depth
     | where { $in.cwd | path split | length | $in <= $max_depth }
@@ -1774,8 +1773,8 @@ export def 'nu-completions-cwds' [] {
 }
 
 export def 'replace-in-all-files' [
-    $find
-    $replace
+    find
+    replace
     --quiet # Don't output stats
     --no-git-check
     --no-rg

--- a/nu-goodies/lazytests/cprint_testing.nu
+++ b/nu-goodies/lazytests/cprint_testing.nu
@@ -29,7 +29,7 @@ Output:
 ```
 
 ```nu
-cprint $text --keep_single_breaks --indent 4
+cprint $text --keep-single-breaks --indent 4
 ```
 
 Output:
@@ -176,7 +176,7 @@ Output:
 ```
 
 ```nu
-cprint $text --lines_before 3 --echo
+cprint $text --lines-before 3 --echo
 ```
 
 Output:

--- a/nu-goodies/mod.nu
+++ b/nu-goodies/mod.nu
@@ -5,7 +5,7 @@ export use commands.nu [
     "bye"
     # "cb"
     "center"
-    # "check-clean-working-tree"
+    # "git-check-file-clean"
     # "colorit"
     "copy-cmd"
     "cprint"

--- a/nu-goodies/mod.nu
+++ b/nu-goodies/mod.nu
@@ -11,7 +11,6 @@ export use commands.nu [
     "cprint"
     "cd-root"
     # "dedent"
-    "dfr enumerate"
     # "download-nushell-nightly"
     # "escape-nushell-escapes"
     # "escape-regex"


### PR DESCRIPTION
## Summary

This PR brings the codebase in line with Nushell conventions and includes several functional improvements.

### Code Style Standardization
- **Flags**: Convert `snake_case` flags to `kebab-case` (`--no_date` → `--no-date`, `--keep_single_breaks` → `--keep-single-breaks`, etc.)
- **Functions**: Convert `snake_case` function names to `kebab-case` (`rand_hex_col2` → `rand-hex-col2`, `generate_colors` → `generate-colors`, etc.)
- **Completions**: Standardize completion function naming to `completions-*` prefix (`nu-complete-macos-apps` → `completions-macos-apps`)
- **Type annotations**: Add input/output type annotations to all exported commands

### Functional Improvements
- **`replace-in-all-files`**: Add `--fixed-strings` to ripgrep to handle special regex characters like `$` in search strings (e.g., `$nu.home-path`)
- **`z` command**:
  - SQL-level filtering for dead directories (performance improvement)
  - Show open Zellij tabs in completions with ⇆ indicator
  - Use parameterized SQL queries to prevent injection
  - Simplify logic with extracted helper functions (`zellij-navigate`, `find-first-existing`, etc.)
- **`rand-hex-col2`**: Refactor from `mut`+`for` loop to functional `generate` pattern

### Documentation
- Add descriptions to exported commands and their options
- Add inline comments explaining function purposes

### Other
- Add `.claude/settings.local.json` to `.gitignore`
- Rename `check-clean-working-tree` → `git-check-file-clean` with `--porcelain` flag for stable output

🤖 Generated with [Claude Code](https://claude.ai/code)
